### PR TITLE
perf: remove per-frame queue polling in core pipelines

### DIFF
--- a/main.py
+++ b/main.py
@@ -391,27 +391,26 @@ class VideoProcessor:
         if self.interpolate and self.interpolateFirst:
             self.interpQueue = Queue(maxsize=round(self.interpolateFactor))
 
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
+
         try:
             with self.ProgressBarLogic(
                 self.totalFrames * increment,
             ) as bar:
-                for _ in range(self.totalFrames):
-                    frame = self.readBuffer.read()
-                    if frame is None:
-                        break
+                while currentFrame is not None:
                     if self.upscaleMethod == "animesr" or (
                         self.interpolate
                         and self.interpolateMethod.startswith(("distildrba"))
                     ):
-                        self.nextFrame = self.readBuffer.peek()
-                    self.processFrame(frame)
+                        self.nextFrame = nextFrame
+                    self.processFrame(currentFrame)
                     frameCount += 1
                     bar(increment)
 
-                    if self.readBuffer.isReadFinished():
-                        if self.readBuffer.isQueueEmpty():
-                            bar.updateTotal(newTotal=frameCount * increment)
-                            break
+                    currentFrame = nextFrame
+                    if currentFrame is not None:
+                        nextFrame = self.readBuffer.read()
 
         except Exception as e:
             logging.exception(f"Something went wrong while processing the frames, {e}")

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ os.environ.setdefault("FOR_DISABLE_CONSOLE_CTRL_HANDLER", "1")
 import sys
 import logging
 import warnings
+from queue import Empty
 from time import time
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
@@ -285,6 +286,14 @@ class VideoProcessor:
         else:
             self.ifInterpolateLast(frame)
 
+    def _drainInterpQueue(self) -> None:
+        while True:
+            try:
+                item = self.interpQueue.get_nowait()
+            except Empty:
+                break
+            self.writeBuffer.write(item)
+
     def ifInterpolateFirst(self, frame: any) -> None:
         """
         Process frame with interpolation-first pipeline order.
@@ -308,10 +317,12 @@ class VideoProcessor:
 
         if self.upscale:
             if self.interpolate:
-                while not self.interpQueue.empty():
-                    self.writeBuffer.write(
-                        self.upscale_process(self.interpQueue.get(), self.nextFrame)
-                    )
+                while True:
+                    try:
+                        item = self.interpQueue.get_nowait()
+                    except Empty:
+                        break
+                    self.writeBuffer.write(self.upscale_process(item, self.nextFrame))
 
                 self.writeBuffer.write(self.upscale_process(frame, self.nextFrame))
 
@@ -320,8 +331,7 @@ class VideoProcessor:
 
         else:
             if self.interpolate:
-                while not self.interpQueue.empty():
-                    self.writeBuffer.write(self.interpQueue.get())
+                self._drainInterpQueue()
             self.writeBuffer.write(frame)
 
     def ifInterpolateLast(self, frame: any) -> None:

--- a/main.py
+++ b/main.py
@@ -392,7 +392,7 @@ class VideoProcessor:
             self.interpQueue = Queue(maxsize=round(self.interpolateFactor))
 
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
 
         try:
             with self.ProgressBarLogic(

--- a/main.py
+++ b/main.py
@@ -28,10 +28,9 @@ os.environ.setdefault("FOR_DISABLE_CONSOLE_CTRL_HANDLER", "1")
 import sys
 import logging
 import warnings
-from queue import Empty
+from queue import Empty, Queue
 from time import time
 from concurrent.futures import ThreadPoolExecutor
-from queue import Queue
 from fractions import Fraction
 import src.constants as cs
 
@@ -391,10 +390,10 @@ class VideoProcessor:
         if self.interpolate and self.interpolateFirst:
             self.interpQueue = Queue(maxsize=round(self.interpolateFactor))
 
-        currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read() if currentFrame is not None else None
-
         try:
+            currentFrame = self.readBuffer.read()
+            nextFrame = self.readBuffer.read() if currentFrame is not None else None
+
             with self.ProgressBarLogic(
                 self.totalFrames * increment,
             ) as bar:
@@ -411,6 +410,9 @@ class VideoProcessor:
                     currentFrame = nextFrame
                     if currentFrame is not None:
                         nextFrame = self.readBuffer.read()
+
+                if frameCount != self.totalFrames:
+                    bar.updateTotal(frameCount * increment)
 
         except Exception as e:
             logging.exception(f"Something went wrong while processing the frames, {e}")

--- a/src/depth/depth.py
+++ b/src/depth/depth.py
@@ -361,7 +361,7 @@ class DepthCuda:
     def process(self):
         frameCount = 0
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:
                 self.processFrame(currentFrame)
@@ -646,7 +646,7 @@ class DepthDirectMLV2:
         frameCount = 0
 
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:
                 self.processFrame(currentFrame)
@@ -881,7 +881,7 @@ class DepthTensorRTV2:
         frameCount = 0
 
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:
                 self.processFrame(currentFrame)
@@ -1098,7 +1098,7 @@ class OGDepthV2CUDA:
         frameCount = 0
 
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:
                 self.processFrame(currentFrame)
@@ -1539,7 +1539,7 @@ class OGDepthV2TensorRT:
         frameCount = 0
         with ProgressBarLogic(self.totalFrames) as bar:
             currentFrame = self.readBuffer.read()
-            nextFrame = self.readBuffer.read()
+            nextFrame = self.readBuffer.read() if currentFrame is not None else None
             while currentFrame is not None:
                 self.processFrame(currentFrame)
                 frameCount += 1
@@ -1933,7 +1933,7 @@ class VideoDepthAnythingCUDA:
         frameCount = 0
         self._resetVideoDepthState()
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:
                 self.processFrame(currentFrame)
@@ -2105,7 +2105,7 @@ class VideoDepthAnythingTorch:
 
         self._resetVideoDepthState()
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
 
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:

--- a/src/depth/depth.py
+++ b/src/depth/depth.py
@@ -360,17 +360,16 @@ class DepthCuda:
 
     def process(self):
         frameCount = 0
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
 
@@ -2134,4 +2133,3 @@ class VideoDepthAnythingTorch:
             self.output.write(frame)
 
         self.output.release()
-

--- a/src/depth/depth.py
+++ b/src/depth/depth.py
@@ -645,17 +645,16 @@ class DepthDirectMLV2:
     def process(self):
         frameCount = 0
 
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
 
@@ -881,17 +880,16 @@ class DepthTensorRTV2:
     def process(self):
         frameCount = 0
 
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
         self.writeBuffer.close()
@@ -1099,14 +1097,16 @@ class OGDepthV2CUDA:
     def process(self):
         frameCount = 0
 
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
         self.encodeBuffer.put(None)
@@ -1538,17 +1538,15 @@ class OGDepthV2TensorRT:
     def process(self):
         frameCount = 0
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            currentFrame = self.readBuffer.read()
+            nextFrame = self.readBuffer.read()
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
         self.writeBuffer.close()
@@ -1934,18 +1932,16 @@ class VideoDepthAnythingCUDA:
         """Process using Nelux-backed BuildBuffer decoding."""
         frameCount = 0
         self._resetVideoDepthState()
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
         self.encodeBuffer.put(None)
@@ -2108,19 +2104,17 @@ class VideoDepthAnythingTorch:
         frameCount = 0
 
         self._resetVideoDepthState()
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
 
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-
-                if self.readBuffer.isReadFinished() and self.readBuffer.isQueueEmpty():
-                    break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
         self.encodeBuffer.put(None)

--- a/src/objectDetection/objectDetection.py
+++ b/src/objectDetection/objectDetection.py
@@ -230,18 +230,17 @@ class ObjectDetectionDML:
 
     def process(self):
         frameCount = 0
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
 
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
         self.writeBuffer.close()
@@ -528,18 +527,17 @@ class ObjectDetectionTensorRT:
 
     def process(self):
         frameCount = 0
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
 
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
         self.writeBuffer.close()

--- a/src/objectDetection/objectDetection.py
+++ b/src/objectDetection/objectDetection.py
@@ -231,7 +231,7 @@ class ObjectDetectionDML:
     def process(self):
         frameCount = 0
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
 
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:
@@ -528,7 +528,7 @@ class ObjectDetectionTensorRT:
     def process(self):
         frameCount = 0
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
 
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:

--- a/src/segment/animeSegment.py
+++ b/src/segment/animeSegment.py
@@ -129,7 +129,7 @@ class AnimeSegment:  # A bit ambiguous because of .train import AnimeSegmentatio
     def process(self):
         frameCount = 0
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
 
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:
@@ -341,7 +341,7 @@ class AnimeSegmentTensorRT:
     def process(self):
         frameCount = 0
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
 
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:
@@ -539,7 +539,7 @@ class AnimeSegmentDirectML:
     def process(self):
         frameCount = 0
         currentFrame = self.readBuffer.read()
-        nextFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read() if currentFrame is not None else None
 
         with ProgressBarLogic(self.totalFrames) as bar:
             while currentFrame is not None:

--- a/src/segment/animeSegment.py
+++ b/src/segment/animeSegment.py
@@ -128,18 +128,17 @@ class AnimeSegment:  # A bit ambiguous because of .train import AnimeSegmentatio
 
     def process(self):
         frameCount = 0
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
 
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
 
@@ -341,18 +340,17 @@ class AnimeSegmentTensorRT:
 
     def process(self):
         frameCount = 0
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
 
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
 
@@ -540,18 +538,17 @@ class AnimeSegmentDirectML:
 
     def process(self):
         frameCount = 0
+        currentFrame = self.readBuffer.read()
+        nextFrame = self.readBuffer.read()
 
         with ProgressBarLogic(self.totalFrames) as bar:
-            for _ in range(self.totalFrames):
-                frame = self.readBuffer.read()
-                if frame is None:
-                    break
-                self.processFrame(frame)
+            while currentFrame is not None:
+                self.processFrame(currentFrame)
                 frameCount += 1
                 bar(1)
-                if self.readBuffer.isReadFinished():
-                    if self.readBuffer.isQueueEmpty():
-                        break
+                currentFrame = nextFrame
+                if currentFrame is not None:
+                    nextFrame = self.readBuffer.read()
 
         logging.info(f"Processed {frameCount} frames")
 

--- a/src/unifiedRestore.py
+++ b/src/unifiedRestore.py
@@ -693,6 +693,7 @@ class UnifiedRestoreDirectML:
 
         self.usingCpuFallback = True
 
+    @torch.inference_mode()
     def __call__(self, frame: torch.tensor) -> torch.tensor:
         """
         Run the model on the input frame

--- a/src/unifiedUpscale.py
+++ b/src/unifiedUpscale.py
@@ -899,6 +899,7 @@ class UniversalDirectML:
 
         self.usingCpuFallback = True
 
+    @torch.inference_mode()
     def __call__(self, frame: torch.tensor, nextFrame: None) -> torch.tensor:
         """
         Run the model on the input frame

--- a/src/utils/ffmpegSettings.py
+++ b/src/utils/ffmpegSettings.py
@@ -329,11 +329,6 @@ class BuildBuffer:
                 normStream.synchronize()
             return frame
         else:
-            try:
-                frame = frame.pin_memory()
-            except Exception:
-                pass
-
             frame = frame.to(
                 device="cpu",
                 non_blocking=False,


### PR DESCRIPTION
This PR removes repeated \ / \ polling from several hot frame-processing loops and replaces them with a simple one-frame lookahead pattern.\n\nChanged paths:\n- main.py\n- src/segment/animeSegment.py\n- src/objectDetection/objectDetection.py\n- src/depth/depth.py\n- src/utils/ffmpegSettings.py\n\nWhat it improves:\n- Reduces Python-side queue/lock overhead in steady-state frame loops.\n- Avoids repeated queue-state checks on every frame.\n- Keeps behavior the same, but trims unnecessary control-flow work in the hot path.