### PR TITLE
Fix/channels last processframe

### DIFF
--- a/src/unifiedUpscale.py
+++ b/src/unifiedUpscale.py
@@ -224,10 +224,7 @@ class UniversalPytorch:
     def processFrame(self, frame):
         with torch.cuda.stream(self.normStream):
             self.dummyInput.copy_(
-                frame.to(
-                    dtype=self.dummyInput.dtype,
-                    memory_format=torch.channels_last,
-                ),
+                frame.to(dtype=self.dummyInput.dtype),
                 non_blocking=True,
             )
         self.normStream.synchronize()

--- a/src/utils/ffmpegSettings.py
+++ b/src/utils/ffmpegSettings.py
@@ -325,8 +325,6 @@ class BuildBuffer:
                 else:
                     frame = frame.unsqueeze(0)
 
-                frame = frame.to(memory_format=torch.channels_last)
-
             if normStream is not None:
                 normStream.synchronize()
             return frame

--- a/src/utils/ffmpegSettings.py
+++ b/src/utils/ffmpegSettings.py
@@ -325,6 +325,8 @@ class BuildBuffer:
                 else:
                     frame = frame.unsqueeze(0)
 
+                frame = frame.to(memory_format=torch.channels_last)
+
             if normStream is not None:
                 normStream.synchronize()
             return frame


### PR DESCRIPTION
UniversalPytorch.processFrame called .to(memory_format=channels_last)
creating a temporary tensor, then .copy_() into dummyInput producing
2 copies per frame. Removing the intermediate lets copy_() handle
the format conversion directly — 1 copy instead of 2.
