### PR TITLE
batch fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,9 @@ from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 from fractions import Fraction
 import src.constants as cs
+import torch
+
+torch.set_float32_matmul_precision("medium")
 
 warnings.filterwarnings("ignore")
 

--- a/src/dedup/dedup.py
+++ b/src/dedup/dedup.py
@@ -50,18 +50,10 @@ class DedupSSIMCuda:
             return True
 
     def processFrame(self, frame):
-        return (
-            F.interpolate(
-                frame.half(),
-                (self.sampleSize, self.sampleSize),
-                mode="nearest",
-            )
-            if self.half
-            else F.interpolate(
-                frame.float(),
-                (self.sampleSize, self.sampleSize),
-                mode="nearest",
-            )
+        return F.interpolate(
+            frame if self.half else frame.float(),
+            (self.sampleSize, self.sampleSize),
+            mode="nearest",
         )
 
 
@@ -185,19 +177,11 @@ class DedupMSECuda:
             return False
 
     def processFrame(self, frame):
-        return (
-            F.interpolate(
-                frame.half(),
-                (self.sampleSize, self.sampleSize),
-                mode="nearest",
-            ).mul(255.0)
-            if self.half
-            else F.interpolate(
-                frame.float(),
-                (self.sampleSize, self.sampleSize),
-                mode="nearest",
-            ).mul(255.0)
-        )
+        return F.interpolate(
+            frame if self.half else frame.float(),
+            (self.sampleSize, self.sampleSize),
+            mode="nearest",
+        ).mul(255.0)
 
 
 class DedupFlownetS:

--- a/src/unifiedInterpolate.py
+++ b/src/unifiedInterpolate.py
@@ -1484,51 +1484,33 @@ class RifeDirectML:
                 self.modelPath, providers=["CPUExecutionProvider"]
             )
 
-        self.needsOutputSync = any(
-            provider in self.model.get_providers()
-            for provider in ("DmlExecutionProvider", "OpenVINOExecutionProvider")
+        self.I0Np = np.zeros(
+            (1, 3, self.ph, self.pw),
+            dtype=self.numpyDType,
         )
+        self.I0 = torch.from_numpy(self.I0Np)
 
-        self.IoBinding = self.model.io_binding()
-        self.I0 = torch.zeros(
-            1,
-            3,
-            self.ph,
-            self.pw,
-            dtype=self.dtype,
-            device=self.device,
-        ).contiguous()
+        self.I1Np = np.zeros(
+            (1, 3, self.ph, self.pw),
+            dtype=self.numpyDType,
+        )
+        self.I1 = torch.from_numpy(self.I1Np)
 
-        self.I1 = torch.zeros(
-            1,
-            3,
-            self.ph,
-            self.pw,
-            dtype=self.dtype,
-            device=self.device,
-        ).contiguous()
-
-        self.dummyTimeStep = torch.full(
+        self.dummyTimeStepNp = np.full(
             (1, 1, self.ph, self.pw),
             0.5,
-            dtype=self.dtype,
-            device=self.device,
-        ).contiguous()
-
-        self.dummyOutput = torch.zeros(
-            (1, 3, self.height, self.width),
-            device=self.device,
-            dtype=self.dtype,
-        ).contiguous()
-
-        self.IoBinding.bind_output(
-            name="output",
-            device_type=self.deviceType,
-            device_id=0,
-            element_type=self.numpyDType,
-            shape=self.dummyOutput.shape,
-            buffer_ptr=self.dummyOutput.data_ptr(),
+            dtype=self.numpyDType,
         )
+        self.dummyTimeStep = torch.from_numpy(self.dummyTimeStepNp)
+
+        self.dummyOutputNp = np.zeros(
+            (1, 3, self.height, self.width),
+            dtype=self.numpyDType,
+        )
+        self.dummyOutput = torch.from_numpy(self.dummyOutputNp)
+
+        self.inputName = self.model.get_inputs()[0].name
+        self.outputName = self.model.get_outputs()[0].name
 
 
 
@@ -1577,30 +1559,6 @@ class RifeDirectML:
 
         self.processFrame(frame, "I1")
 
-        self.IoBinding.bind_input(
-            name="img0",
-            device_type=self.deviceType,
-            device_id=0,
-            element_type=self.numpyDType,
-            shape=self.I0.shape,
-            buffer_ptr=self.I0.data_ptr(),
-        )
-        self.IoBinding.bind_input(
-            name="img1",
-            device_type=self.deviceType,
-            device_id=0,
-            element_type=self.numpyDType,
-            shape=self.I1.shape,
-            buffer_ptr=self.I1.data_ptr(),
-        )
-        self.IoBinding.bind_input(
-            name="timestep",
-            device_type=self.deviceType,
-            device_id=0,
-            element_type=self.numpyDType,
-            shape=self.dummyTimeStep.shape,
-            buffer_ptr=self.dummyTimeStep.data_ptr(),
-        )
         for i in range(framesToInsert):
             if timesteps is not None and i < len(timesteps):
                 t = timesteps[i]
@@ -1609,9 +1567,15 @@ class RifeDirectML:
 
             self.dummyTimeStep.fill_(t)
 
-            self.model.run_with_iobinding(self.IoBinding)
-            if self.needsOutputSync:
-                self.IoBinding.synchronize_outputs()
+            outputs = self.model.run(
+                [self.outputName],
+                {
+                    "img0": self.I0Np,
+                    "img1": self.I1Np,
+                    "timestep": self.dummyTimeStepNp,
+                },
+            )
+            np.copyto(self.dummyOutputNp, outputs[0])
 
             interpQueue.put(self.dummyOutput.clone())
 

--- a/src/unifiedInterpolate.py
+++ b/src/unifiedInterpolate.py
@@ -17,9 +17,6 @@ if ADOBE:
 
 checker = CudaChecker()
 
-torch.set_float32_matmul_precision("medium")
-
-
 _RIFE_V1 = {
     "rife":           ("IFNet425",      "IFNet_rife425"),
     "rife4.25":       ("IFNet425",      "IFNet_rife425"),
@@ -772,8 +769,6 @@ class RifeTensorRT:
         self.handleModel()
 
     def handleModel(self):
-        if self.half:
-            torch.set_default_dtype(torch.float16)
         self.filename = modelsMap(
             self.interpolateMethod.replace("-tensorrt", ""),
             modelType="pth",
@@ -1341,8 +1336,6 @@ class RifeDirectML:
             self.numpyDType = np.float32
             self.torchDType = torch.float32
 
-        if self.half:
-            torch.set_default_dtype(torch.float16)
         self.filename = modelsMap(
             self.interpolateMethod.replace("-directml", ""),
             modelType="pth",

--- a/src/unifiedUpscale.py
+++ b/src/unifiedUpscale.py
@@ -13,9 +13,6 @@ if ADOBE:
 
 checker = CudaChecker()
 
-torch.set_float32_matmul_precision("medium")
-
-
 def calculatePadding(width, height, multiple=4):
     padW = (multiple - (width % multiple)) % multiple
     padH = (multiple - (height % multiple)) % multiple

--- a/src/utils/ffmpegSettings.py
+++ b/src/utils/ffmpegSettings.py
@@ -999,6 +999,7 @@ class WriteBuffer:
             else:
                 from concurrent.futures import ThreadPoolExecutor
 
+                # Use a single‑worker thread pool to serialize ffmpeg writes while allowing the main thread to continue frame conversion.
                 with ThreadPoolExecutor(max_workers=1) as cpuWritePool:
                     pendingWrite = None
 
@@ -1011,9 +1012,7 @@ class WriteBuffer:
                         if frame is None:
                             break
 
-                        if pendingWrite is not None:
-                            pendingWrite.result()
-
+                        # Resize if needed and convert the tensor to raw bytes for ffmpeg.
                         if needsResize:
                             frame = F.interpolate(
                                 frame,
@@ -1032,11 +1031,13 @@ class WriteBuffer:
                             .tobytes()
                         )
 
+                        # Submit the write operation without awaiting it, enabling overlap.
                         pendingWrite = cpuWritePool.submit(
                             ffmpegProc.stdin.write, frameBytes
                         )
                         writtenFrames += 1
 
+                    # Ensure the final write completes before exiting.
                     if pendingWrite is not None:
                         pendingWrite.result()
 

--- a/src/utils/ffmpegSettings.py
+++ b/src/utils/ffmpegSettings.py
@@ -997,33 +997,48 @@ class WriteBuffer:
                     bufferIdx = 1 - bufferIdx
 
             else:
-                while True:
-                    try:
-                        frame = self.writeBuffer.get(timeout=1.0)
-                    except Exception:
-                        time.sleep(0.001)
-                        continue
-                    if frame is None:
-                        break
+                from concurrent.futures import ThreadPoolExecutor
 
-                    if needsResize:
-                        frame = F.interpolate(
-                            frame,
-                            size=(self.height, self.width),
-                            mode="bicubic",
-                            align_corners=False,
+                with ThreadPoolExecutor(max_workers=1) as cpuWritePool:
+                    pendingWrite = None
+
+                    while True:
+                        try:
+                            frame = self.writeBuffer.get(timeout=1.0)
+                        except Exception:
+                            time.sleep(0.001)
+                            continue
+                        if frame is None:
+                            break
+
+                        if pendingWrite is not None:
+                            pendingWrite.result()
+
+                        if needsResize:
+                            frame = F.interpolate(
+                                frame,
+                                size=(self.height, self.width),
+                                mode="bicubic",
+                                align_corners=False,
+                            )
+                        frameBytes = (
+                            frame.squeeze(0)
+                            .permute(1, 2, 0)
+                            .mul(multiplier)
+                            .clamp(0, multiplier)
+                            .to(dtype)
+                            .contiguous()
+                            .numpy()
+                            .tobytes()
                         )
-                    frameTensor = (
-                        frame.squeeze(0)
-                        .permute(1, 2, 0)
-                        .mul(multiplier)
-                        .clamp(0, multiplier)
-                        .to(dtype)
-                        .contiguous()
-                    )
 
-                    ffmpegProc.stdin.write(frameTensor.numpy().tobytes())
-                    writtenFrames += 1
+                        pendingWrite = cpuWritePool.submit(
+                            ffmpegProc.stdin.write, frameBytes
+                        )
+                        writtenFrames += 1
+
+                    if pendingWrite is not None:
+                        pendingWrite.result()
 
             logging.info(f"Encoded {writtenFrames} frames")
 


### PR DESCRIPTION
Batch small fixes: dedup dtype, default_dtype, matmul_precision, CPU pong

- DedupSSIMCuda/DedupMSECuda: hoist dtype branching from per-frame
  if/else into a single F.interpolate call
- RifeTensorRT/RifeDirectML: remove global torch.set_default_dtype
  side effect on fp16
- Remove duplicate torch.set_float32_matmul_precision from
  unifiedUpscale + unifiedInterpolate, set once in main()
- WriteBuffer CPU path: add ThreadPoolExecutor pong pattern so
  pipe writes overlap with next frame's tensor conversion