### PR TITLE
perf(startup): cut upscale cold start ~30% via lazy imports + leaner warmup

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Performance
 - **Motion blur is faster on CUDA** — only the frames inside the shutter window are interpolated. ~1.5× faster at the default shutter 180, up to ~3× at shutter 90. Output is unchanged; TensorRT/DirectML and shutter 360 are unaffected.
+- **Upscale cold start ~30% faster** (launch → first frame on the CUDA/PyTorch path, e.g. `shufflecugan`; measured ~3.5s → ~2.5s at 720p on an RTX 3090). Output is byte-identical and all backends are unaffected. Five independent startup wins:
+  - Made the `torchvision` imports in the vendored spandrel `LaMa`/`RestoreFormer` arches lazy (moved to call-site). The eager architecture registry imported `torchvision` (which drags in `torch._dynamo`, ~1s) at every startup even though the upscale model in use almost never touches those arches (~−740ms).
+  - Removed two dead `from sympy import true` / `from sympy import false` imports (accidental auto-imports, never referenced) in the `SPANPlus`/`sudo_SPANPlus` arches that pulled in `sympy` during the registry build (~−290ms).
+  - Reduced the pre-CUDA-graph warmup in `UniversalPytorch` from 5 to 3 iterations — `cudnn.benchmark` is off so the algorithm is fixed and 3 warmups suffice to prepare cudnn kernels/workspace before capture; the captured graph (and thus output) is identical (~−100ms).
+  - Made `cv2` lazy in `ffmpegSettings` (only the OpenCV decode fallback and single-image PNG writer use it) (~−13ms), and read the Windows CPU name from `PROCESSOR_IDENTIFIER` instead of `platform.processor()`'s WMI shell-out in `checkSpecs` (~−25ms).
 
 
 ## [2.7.7] - 2026-06-01

--- a/src/spandrel/libs/spandrel/spandrel/architectures/LaMa/__arch/LaMa.py
+++ b/src/spandrel/libs/spandrel/spandrel/architectures/LaMa/__arch/LaMa.py
@@ -10,7 +10,6 @@ Model adapted from advimman's lama project: https://github.com/advimman/lama
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torchvision.transforms.functional import InterpolationMode, rotate
 
 from ....util import store_hyperparameters
 
@@ -37,6 +36,11 @@ class LearnableSpatialTransformWrapper(nn.Module):
             raise ValueError(f"Unexpected input type {type(x)}")
 
     def transform(self, x):
+        # torchvision is imported lazily: importing this arch module for
+        # registry registration must not drag in torchvision (+ torch._dynamo),
+        # ~1s of cold-start cost paid only when LaMa actually runs.
+        from torchvision.transforms.functional import InterpolationMode, rotate
+
         height, width = x.shape[2:]
         pad_h, pad_w = int(height * self.pad_coef), int(width * self.pad_coef)
         x_padded = F.pad(x, [pad_w, pad_w, pad_h, pad_h], mode="reflect")
@@ -47,6 +51,8 @@ class LearnableSpatialTransformWrapper(nn.Module):
         return x_padded_rotated
 
     def inverse_transform(self, y_padded_rotated, orig_x):
+        from torchvision.transforms.functional import InterpolationMode, rotate
+
         height, width = orig_x.shape[2:]
         pad_h, pad_w = int(height * self.pad_coef), int(width * self.pad_coef)
 

--- a/src/spandrel/libs/spandrel/spandrel/architectures/RestoreFormer/__init__.py
+++ b/src/spandrel/libs/spandrel/spandrel/architectures/RestoreFormer/__init__.py
@@ -1,5 +1,4 @@
 import torch
-from torchvision.transforms.functional import normalize as tv_normalize
 from typing_extensions import override
 
 from ...util import KeyCondition, get_seq_len
@@ -83,6 +82,10 @@ class RestoreFormerArch(Architecture[RestoreFormer]):
         )
 
         def call(model: RestoreFormer, x: torch.Tensor) -> torch.Tensor:
+            # Lazy import: keep torchvision out of the arch-registry import path
+            # (see LaMa) so it is only loaded when RestoreFormer actually runs.
+            from torchvision.transforms.functional import normalize as tv_normalize
+
             x = tv_normalize(x, [0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
             result = model(x)[0]
             return (result + 1) / 2

--- a/src/spandrel/libs/spandrel/spandrel/architectures/SPANPlus/__init__.py
+++ b/src/spandrel/libs/spandrel/spandrel/architectures/SPANPlus/__init__.py
@@ -1,4 +1,3 @@
-from sympy import true
 from typing_extensions import override
 
 from ...__helpers.model_descriptor import Architecture, ImageModelDescriptor, StateDict

--- a/src/spandrel/libs/spandrel/spandrel/architectures/sudo_SPANPlus/__init__.py
+++ b/src/spandrel/libs/spandrel/spandrel/architectures/sudo_SPANPlus/__init__.py
@@ -1,4 +1,3 @@
-from sympy import false
 from typing_extensions import override
 
 from ...util import KeyCondition, get_scale_and_output_channels

--- a/src/unifiedUpscale.py
+++ b/src/unifiedUpscale.py
@@ -213,7 +213,10 @@ class UniversalPytorch:
         self.stream = torch.cuda.Stream()
 
         with torch.cuda.stream(self.stream):
-            for _ in range(5):
+            # 3 warmup iters before CUDA-graph capture: cudnn.benchmark is False
+            # (no algo autotune), so 3 is sufficient to JIT cudnn kernels +
+            # allocate workspace before capture (PyTorch-documented minimum).
+            for _ in range(3):
                 self.model(self.dummyInput)
                 self.stream.synchronize()
 

--- a/src/utils/checkSpecs.py
+++ b/src/utils/checkSpecs.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import psutil
 import platform
 from src.constants import SYSTEM
@@ -11,7 +12,9 @@ def getWindowsInfo():
     ramInfo = psutil.virtual_memory()
     totalRam = round(ramInfo.total / (1024.0**3), 2)
 
-    cpuInfo = platform.processor()
+    # platform.processor() shells out to WMI/registry (~12-28ms) and returns
+    # exactly PROCESSOR_IDENTIFIER on Windows; read the env directly when set.
+    cpuInfo = os.environ.get("PROCESSOR_IDENTIFIER") or platform.processor()
 
     logging.info(f"OS: {osName} {osVersion}")
     logging.info(f"CPU: {cpuInfo}")

--- a/src/utils/ffmpegSettings.py
+++ b/src/utils/ffmpegSettings.py
@@ -6,7 +6,6 @@ import time
 import torch
 import nelux
 import threading
-import cv2
 
 from queue import Queue
 from src.utils.encodingSettings import matchEncoder, getPixFMT
@@ -237,6 +236,8 @@ class BuildBuffer:
         Returns the number of frames decoded.
         """
         logging.info(f"Initializing OpenCV VideoCapture for {self.videoInput}")
+
+        import cv2  # lazy: cv2 (~13ms) is only needed on the OpenCV decode fallback
 
         cap = cv2.VideoCapture(self.videoInput)
         if not cap.isOpened():
@@ -520,6 +521,8 @@ class WriteBuffer:
 
         if frameArray.ndim == 3 and frameArray.shape[2] == 1:
             frameArray = frameArray[:, :, 0]
+
+        import cv2  # lazy: only needed for single-image (PNG) output
 
         cvWriteFrame = frameArray
         if frameArray.ndim == 3 and frameArray.shape[2] == 3:


### PR DESCRIPTION
## Summary

Launch -> first-frame on the CUDA/PyTorch upscale path (e.g. `shufflecugan`) drops ~3.5s -> ~2.5s at 720p (RTX 3090). Output byte-identical, 158 tests green.

Five independent startup wins:

- **spandrel LaMa/RestoreFormer: lazy torchvision imports** (moved to call-site). The eager arch registry pulled torchvision + `torch._dynamo` (~1s) at every startup even though most upscale models never touch those arches. (~-740ms)
- **SPANPlus/sudo_SPANPlus: remove dead `from sympy import true/false`** (accidental auto-imports, never referenced) that pulled sympy during registry build. (~-290ms)
- **UniversalPytorch: reduce pre-CUDA-graph warmup 5 -> 3 iters.** `cudnn.benchmark` is off so the algorithm is fixed and 3 warmups suffice; captured graph identical. (~-100ms)
- **ffmpegSettings: lazy cv2** (only the OpenCV decode fallback and single-image PNG writer use it). (~-13ms)
- **checkSpecs: read `PROCESSOR_IDENTIFIER`** instead of `platform.processor()` WMI shell-out on Windows; identical CPU string. (~-25ms)

## Test plan

- [x] `python -m pytest tests/ -q` — 158 green
- [x] Cold-start A/B: byte-identical output vs main, ~3.5s -> ~2.5s launch->first-frame at 720p