### PR TITLE
refactor(spandrel): hoist lazy torchvision imports out of per-call paths

### DIFF
--- a/src/spandrel/libs/spandrel/spandrel/architectures/LaMa/__arch/LaMa.py
+++ b/src/spandrel/libs/spandrel/spandrel/architectures/LaMa/__arch/LaMa.py
@@ -17,6 +17,14 @@ from ....util import store_hyperparameters
 class LearnableSpatialTransformWrapper(nn.Module):
     def __init__(self, impl, pad_coef=0.5, angle_init_range=80, train_angle=True):
         super().__init__()
+        # torchvision is imported lazily, here rather than at module level:
+        # importing this arch module for registry registration must not drag in
+        # torchvision (+ torch._dynamo), ~1s of cold-start cost paid only when
+        # a LaMa model is actually instantiated.
+        from torchvision.transforms.functional import InterpolationMode, rotate
+
+        self._rotate = rotate
+        self._bilinear = InterpolationMode.BILINEAR
         self.impl = impl
         self.angle = torch.rand(1) * angle_init_range
         if train_angle:
@@ -44,8 +52,8 @@ class LearnableSpatialTransformWrapper(nn.Module):
         height, width = x.shape[2:]
         pad_h, pad_w = int(height * self.pad_coef), int(width * self.pad_coef)
         x_padded = F.pad(x, [pad_w, pad_w, pad_h, pad_h], mode="reflect")
-        x_padded_rotated = rotate(
-            x_padded, self.angle.to(x_padded), InterpolationMode.BILINEAR, fill=0
+        x_padded_rotated = self._rotate(
+            x_padded, self.angle.to(x_padded), self._bilinear, fill=0
         )
 
         return x_padded_rotated
@@ -56,10 +64,10 @@ class LearnableSpatialTransformWrapper(nn.Module):
         height, width = orig_x.shape[2:]
         pad_h, pad_w = int(height * self.pad_coef), int(width * self.pad_coef)
 
-        y_padded = rotate(
+        y_padded = self._rotate(
             y_padded_rotated,
             -self.angle.to(y_padded_rotated),
-            InterpolationMode.BILINEAR,
+            self._bilinear,
             fill=0,
         )
         y_height, y_width = y_padded.shape[2:]

--- a/src/spandrel/libs/spandrel/spandrel/architectures/LaMa/__arch/LaMa.py
+++ b/src/spandrel/libs/spandrel/spandrel/architectures/LaMa/__arch/LaMa.py
@@ -44,11 +44,6 @@ class LearnableSpatialTransformWrapper(nn.Module):
             raise ValueError(f"Unexpected input type {type(x)}")
 
     def transform(self, x):
-        # torchvision is imported lazily: importing this arch module for
-        # registry registration must not drag in torchvision (+ torch._dynamo),
-        # ~1s of cold-start cost paid only when LaMa actually runs.
-        from torchvision.transforms.functional import InterpolationMode, rotate
-
         height, width = x.shape[2:]
         pad_h, pad_w = int(height * self.pad_coef), int(width * self.pad_coef)
         x_padded = F.pad(x, [pad_w, pad_w, pad_h, pad_h], mode="reflect")
@@ -59,8 +54,6 @@ class LearnableSpatialTransformWrapper(nn.Module):
         return x_padded_rotated
 
     def inverse_transform(self, y_padded_rotated, orig_x):
-        from torchvision.transforms.functional import InterpolationMode, rotate
-
         height, width = orig_x.shape[2:]
         pad_h, pad_w = int(height * self.pad_coef), int(width * self.pad_coef)
 

--- a/src/spandrel/libs/spandrel/spandrel/architectures/RestoreFormer/__init__.py
+++ b/src/spandrel/libs/spandrel/spandrel/architectures/RestoreFormer/__init__.py
@@ -81,11 +81,12 @@ class RestoreFormerArch(Architecture[RestoreFormer]):
             head_size=head_size,
         )
 
-        def call(model: RestoreFormer, x: torch.Tensor) -> torch.Tensor:
-            # Lazy import: keep torchvision out of the arch-registry import path
-            # (see LaMa) so it is only loaded when RestoreFormer actually runs.
-            from torchvision.transforms.functional import normalize as tv_normalize
+        # Lazy import at load() time: keep torchvision out of the arch-registry
+        # import path (see LaMa) so it is only loaded when a RestoreFormer model
+        # is actually loaded, and resolved once rather than per call.
+        from torchvision.transforms.functional import normalize as tv_normalize
 
+        def call(model: RestoreFormer, x: torch.Tensor) -> torch.Tensor:
             x = tv_normalize(x, [0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
             result = model(x)[0]
             return (result + 1) / 2


### PR DESCRIPTION
## Summary

Follow-up to #340, addressing both Copilot review comments: the lazy `torchvision` imports landed inside per-inference code (LaMa `transform`/`inverse_transform`, RestoreFormer `call` closure), so the import statement re-executed every frame (~0.1us cached — cosmetic, but free to fix). This moves them to the latest once-only point:

- **LaMa**: import + bind `rotate` / `InterpolationMode.BILINEAR` in `LearnableSpatialTransformWrapper.__init__` — runs at model build, not at registry import.
- **RestoreFormer**: import `tv_normalize` in `load()` just above the `call` closure.

Cold-start win from #340 is unchanged: arch-registry import remains torchvision-free (asserted via `"torchvision" not in sys.modules` after importing both arch modules).

## Test plan

- [x] Registry import pulls no torchvision/sympy (assert script)
- [x] `pytest tests/ -q` — 158 passed