### PR TITLE
refactor(rifearches): remove remaining unused conv_bn and scenechange stub

### DIFF
--- a/src/rifearches/Rife415_v3.py
+++ b/src/rifearches/Rife415_v3.py
@@ -24,21 +24,6 @@ def conv(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
     )
 
 
-def conv_bn(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
-    return nn.Sequential(
-        nn.Conv2d(
-            in_planes,
-            out_planes,
-            kernel_size=kernel_size,
-            stride=stride,
-            padding=padding,
-            dilation=dilation,
-            bias=False,
-        ),
-        nn.BatchNorm2d(out_planes),
-        nn.LeakyReLU(0.2, True),
-    )
-
 
 class Head(nn.Module):
     def __init__(self):

--- a/src/rifearches/Rife420_v3.py
+++ b/src/rifearches/Rife420_v3.py
@@ -24,21 +24,6 @@ def conv(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
     )
 
 
-def conv_bn(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
-    return nn.Sequential(
-        nn.Conv2d(
-            in_planes,
-            out_planes,
-            kernel_size=kernel_size,
-            stride=stride,
-            padding=padding,
-            dilation=dilation,
-            bias=False,
-        ),
-        nn.BatchNorm2d(out_planes),
-        nn.LeakyReLU(0.2, True),
-    )
-
 
 class Head(nn.Module):
     def __init__(self):

--- a/src/scenechange.py
+++ b/src/scenechange.py
@@ -1,1 +1,0 @@
-"""Scene change detection has been removed from TheAnimeScripter."""


### PR DESCRIPTION
> **Merge after #343 is merged.** (#343 has since been merged — this carries the three files it missed.)

## Summary

Three files not covered by #343:

- `src/rifearches/Rife415_v3.py` — removes unused `conv_bn` helper (15 lines)
- `src/rifearches/Rife420_v3.py` — removes unused `conv_bn` helper (15 lines)
- `src/scenechange.py` — deletes a one-line tombstone comment with no imports and no callers

Net: **-31 lines**, deletions only.

## Test plan

- [x] `python -m pytest tests/ -q` — all tests pass