### PR TITLE
refactor(protocol): add ModelBackend and DepthBackend typing.Protocol

### DIFF
--- a/src/rifearches/Rife415_v3.py
+++ b/src/rifearches/Rife415_v3.py
@@ -24,21 +24,6 @@ def conv(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
     )
 
 
-def conv_bn(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
-    return nn.Sequential(
-        nn.Conv2d(
-            in_planes,
-            out_planes,
-            kernel_size=kernel_size,
-            stride=stride,
-            padding=padding,
-            dilation=dilation,
-            bias=False,
-        ),
-        nn.BatchNorm2d(out_planes),
-        nn.LeakyReLU(0.2, True),
-    )
-
 
 class Head(nn.Module):
     def __init__(self):

--- a/src/rifearches/Rife420_v3.py
+++ b/src/rifearches/Rife420_v3.py
@@ -24,21 +24,6 @@ def conv(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
     )
 
 
-def conv_bn(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
-    return nn.Sequential(
-        nn.Conv2d(
-            in_planes,
-            out_planes,
-            kernel_size=kernel_size,
-            stride=stride,
-            padding=padding,
-            dilation=dilation,
-            bias=False,
-        ),
-        nn.BatchNorm2d(out_planes),
-        nn.LeakyReLU(0.2, True),
-    )
-
 
 class Head(nn.Module):
     def __init__(self):

--- a/src/scenechange.py
+++ b/src/scenechange.py
@@ -1,1 +1,0 @@
-"""Scene change detection has been removed from TheAnimeScripter."""

--- a/src/utils/modelProtocol.py
+++ b/src/utils/modelProtocol.py
@@ -1,0 +1,36 @@
+from typing import Any, Protocol
+
+import torch
+
+
+class ModelBackend(Protocol):
+    """
+    Structural interface shared by all single-model backends
+    (upscale, interpolate, restore, segment, dedup, …).
+
+    Depth backends load more than one model and use handleModels instead —
+    see DepthBackend below.
+
+    Convention (not enforced at runtime):
+      - __init__ accepts the parsed args namespace and stores what it needs.
+      - handleModel loads weights, builds the graph, and warms up the model.
+      - __call__ processes one frame (or one frame-pair for interpolation).
+        The exact extra arguments differ per capability; the first positional
+        argument is always the current frame as a torch.Tensor.
+    """
+
+    def handleModel(self) -> None: ...
+
+    def __call__(
+        self, frame: torch.Tensor, /, *args: Any, **kwargs: Any
+    ) -> torch.Tensor: ...
+
+
+class DepthBackend(Protocol):
+    """Structural interface for depth-estimation backends (multi-model load)."""
+
+    def handleModels(self) -> None: ...
+
+    def __call__(
+        self, frame: torch.Tensor, /, *args: Any, **kwargs: Any
+    ) -> torch.Tensor: ...


### PR DESCRIPTION
> **Merge after #344 is merged.**

## Summary

Adds `src/utils/modelProtocol.py` (36 lines) with two `typing.Protocol` classes:

- `ModelBackend` — structural interface for upscale/interpolate/restore backends: `handleModel() -> None` + `__call__(frame: Tensor, ...) -> Tensor`
- `DepthBackend` — same shape but uses `handleModels()` (plural), matching the depth class convention

Zero runtime overhead — `Protocol` is type-checking only, no ABC machinery. No existing classes changed; new backends can be annotated against these types for static analysis.

## Test plan

- [x] `python -m pytest tests/ -q` — all tests pass