### PR TITLE
Progress bar: spinner with completion receipt + live output size

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Bumped `barflow` `0.4.0` → `0.4.1`.
 - Frame-processing loops (main pipeline, depth, object detection, segment) now terminate on the decoder's end-of-stream sentinel instead of polling queue state every frame; main loop uses a one-frame lookahead instead of queue peeking (#329). Thanks @KRRT7.
-- Bumped `nelux` `0.12.4` → `0.12.6`.
+- Bumped `nelux` `0.12.4` → `0.12.7`.
 
 ### Fixed
 - `--interpolate_method rife4.16-lite` crashed at model download (`ValueError: Model rife4.16-lite not found.`) — the method was wired through the CLI, model init and the arch table but had no `modelsMap` weight mapping. Mapping added (`rife416_lite.pth` / NCNN zips); new registry drift-guard tests (`tests/test_registryDrift.py`) now enforce the choices ↔ registry ↔ `modelsMap` sync so this class of gap fails tests instead of crashing users.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased] - YYYY-MM-DD
 ### Added
-- **Progress bar: leading spinner + completion receipt.** Both the frame and download bars open with an animated braille spinner that flips to a `✔` once the task completes (barflow 0.4.1's receipt). The bar body is unchanged — fill moves only with real progress.
-- **Progress bar: live output filesize + bitrate.** The main pipeline bar shows the growing output file and the encoded content's average bitrate (`… │ 512.3 MB ~12.4Mbps`), polled once per bar refresh on the render thread — zero cost on the frame loop. The in-bar number is a live approximation (the encoder still holds queued frames and the container trailer at that point); the authoritative final size is logged once the writer finishes (`Output Size: 29.5 MB`).
+- Progress bar: leading spinner that turns into a `✔` on completion.
+- Progress bar: live output filesize + bitrate column on the main pipeline bar; exact final size logged after encode (`Output Size: 29.5 MB`).
 - **`--moblur_method`** — pick the motion-blur interpolation model + backend: `rife4.6` / `rife4.25` (CUDA) and their `-tensorrt` / `-directml` variants. Default `rife4.25` (rife4.6 is faster). Previously motion blur reused `--interpolate_method`.
 - Added `smosr` 2x upscale model ([umzi2/SMoSR](https://github.com/umzi2/SMoSR), MIT) across CUDA, MPS, TensorRT, DirectML, and OpenVINO backends. Special thanks to UMZI.
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased] - YYYY-MM-DD
 ### Added
+- **Progress bar: leading spinner + completion receipt.** Both the frame and download bars open with an animated braille spinner that flips to a `✔` once the task completes (barflow 0.4.1's receipt). The bar body is unchanged — fill moves only with real progress.
+- **Progress bar: live output filesize + bitrate.** The main pipeline bar shows the growing output file and the encoded content's average bitrate (`… │ 512.3 MB ~12.4Mbps`), polled once per bar refresh on the render thread — zero cost on the frame loop. The in-bar number is a live approximation (the encoder still holds queued frames and the container trailer at that point); the authoritative final size is logged once the writer finishes (`Output Size: 29.5 MB`).
 - **`--moblur_method`** — pick the motion-blur interpolation model + backend: `rife4.6` / `rife4.25` (CUDA) and their `-tensorrt` / `-directml` variants. Default `rife4.25` (rife4.6 is faster). Previously motion blur reused `--interpolate_method`.
 - Added `smosr` 2x upscale model ([umzi2/SMoSR](https://github.com/umzi2/SMoSR), MIT) across CUDA, MPS, TensorRT, DirectML, and OpenVINO backends. Special thanks to UMZI.
 
 ### Changed
+- Bumped `barflow` `0.4.0` → `0.4.1`.
 - Frame-processing loops (main pipeline, depth, object detection, segment) now terminate on the decoder's end-of-stream sentinel instead of polling queue state every frame; main loop uses a one-frame lookahead instead of queue peeking (#329). Thanks @KRRT7.
 - Bumped `nelux` `0.12.4` → `0.12.6`.
 

--- a/main.py
+++ b/main.py
@@ -396,6 +396,8 @@ class VideoProcessor:
 
             with self.ProgressBarLogic(
                 self.totalFrames * increment,
+                outputPath=self.output,
+                videoFps=self.outputFPS,
             ) as bar:
                 while currentFrame is not None:
                     if self.upscaleMethod == "animesr" or (
@@ -522,6 +524,20 @@ class VideoProcessor:
                 f"Total Execution Time: {elapsedTime:.2f} seconds - FPS: {totalFPS:.2f}",
                 colorFunc="green",
             )
+            # The bar's last filesize sample lands before the encoder
+            # drains its queue and writes the container trailer; this is
+            # the real, final number.
+            try:
+                finalSize = os.path.getsize(self.output)
+            except (OSError, TypeError):
+                finalSize = None
+            if finalSize is not None:
+                sz = (
+                    f"{finalSize / 1024**3:.2f} GB"
+                    if finalSize >= 1024**3
+                    else f"{finalSize / (1024 * 1024):.1f} MB"
+                )
+                logAndPrint(f"Output Size: {sz}", colorFunc="green")
 
             if cs.ADOBE:
                 progressState.setCompleted(outputPath=self.output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ omegaconf==2.3.0
 psutil==7.2.2
 inquirer==3.4.1
 colored==2.3.2
-barflow==0.4.0
+barflow==0.4.1
 python-socketio==5.16.2
 simple-websocket==1.1.0
 werkzeug==3.1.6
-nelux==0.12.6
+nelux==0.12.7

--- a/src/infra/progressBarLogic.py
+++ b/src/infra/progressBarLogic.py
@@ -8,8 +8,10 @@ from barflow.columns import (
     EtaColumn,
     CountColumn,
     CallbackColumn,
+    SpinnerColumn,
 )
 import src.constants as cs
+import os
 from time import time
 from random import choice
 from src.utils.aeComms import progressState
@@ -59,8 +61,45 @@ def _byteCountRender(task):
     return f"{task.completed / mb:6.2f}/{task.total / mb:.2f} MB"
 
 
-def _frameColumns():
-    return (
+def _outputInfoRender(outputPath, videoFps=None):
+    """Callback factory: current output filesize + estimated bitrate.
+
+    Runs on the render thread at the bar's refresh rate (10 Hz) — one
+    os.path.getsize per render, no cost on the frame loop. Returns ""
+    until the encoder creates the file.
+
+    With `videoFps`, bitrate is the encoded content's average bitrate
+    (size over `completed / videoFps` seconds of output video). Without
+    it, falls back to write throughput (size over wall elapsed), which
+    says how fast bytes hit the disk, not how heavy the video is.
+    """
+
+    def render(task):
+        try:
+            size = os.path.getsize(outputPath)
+        except OSError:
+            # Encoder hasn't created the file yet — render nothing,
+            # including the separator (it lives here, not in the column
+            # list, so no dangling "│" before the first write).
+            return ""
+        if videoFps and task.completed > 0:
+            duration = task.completed / videoFps
+        else:
+            duration = task.elapsed
+        mbps = (size * 8 / duration / 1e6) if duration > 0 else 0.0
+        if size >= 1024**3:
+            sz = f"{size / 1024**3:.2f} GB"
+        else:
+            sz = f"{size / (1024 * 1024):.1f} MB"
+        return f" │ {sz} ~{mbps:.1f}Mbps"
+
+    return render
+
+
+def _frameColumns(outputPath=None, videoFps=None):
+    cols = [
+        SpinnerColumn(name="dots", style="bold bright_cyan"),
+        TextColumn(" "),
         DescriptionColumn(style="bold bright_cyan"),
         TextColumn(" "),
         BarColumn(width=None, style="bright_cyan", glyphs="smooth"),
@@ -74,11 +113,18 @@ def _frameColumns():
         CallbackColumn(_fpsRender, style="magenta"),
         _SEP,
         CountColumn(style="green"),
-    )
+    ]
+    if outputPath:
+        cols.append(
+            CallbackColumn(_outputInfoRender(outputPath, videoFps), style="cyan")
+        )
+    return tuple(cols)
 
 
 def _byteColumns():
     return (
+        SpinnerColumn(name="dots", style="bold bright_cyan"),
+        TextColumn(" "),
         DescriptionColumn(style="bold bright_cyan"),
         TextColumn(" "),
         BarColumn(width=None, style="bright_cyan", glyphs="smooth"),
@@ -100,6 +146,8 @@ class ProgressBarLogic:
         self,
         totalFrames: int,
         title: str = None,
+        outputPath: str = None,
+        videoFps: float = None,
     ):
         """
         Initializes the progress bar for the given range of frames.
@@ -107,9 +155,16 @@ class ProgressBarLogic:
         Args:
             totalFrames (int): The total number of frames to process
             title (str): Description shown at the head of the bar
+            outputPath (str): When set, the bar appends a live
+                "filesize ~bitrate" column polled from this file
+            videoFps (float): Output video fps; when set, the bitrate is
+                the encoded content's average (size / output seconds)
+                instead of raw write throughput
         """
         self.totalFrames = totalFrames
         self.title = title or choice(TITLES)
+        self.outputPath = outputPath
+        self.videoFps = videoFps
         self.completed = 0
 
     def __enter__(self):
@@ -131,7 +186,7 @@ class ProgressBarLogic:
 
         else:
             self.progress = Progress(
-                *_frameColumns(),
+                *_frameColumns(self.outputPath, self.videoFps),
                 total=self.totalFrames,
                 desc=self.title,
                 min_interval=_minInterval,


### PR DESCRIPTION
## Changes

- Leading braille spinner on frame/download bars, renders ✔ when the task completes (barflow 0.4.1)
- Main pipeline bar gains a live output filesize + content-bitrate column — one `os.path.getsize` per 10 Hz render tick, render-thread only, zero cost on the frame loop
- Authoritative final size logged after the writer thread joins (the encoder still holds queued frames + container trailer when the bar closes)
- Bump barflow pin 0.4.0 → 0.4.1

## Testing

- Deterministic `render_line` checks: column present with output path, absent without, blank before the encoder creates the file
- Live runs of both bar types with a growing file
- Bitrate math verified: 24.5 MB over 20 s of content → 9.8 Mbps

🤖 Generated with [Claude Code](https://claude.com/claude-code)