### PR TITLE
perf(upscale): speed up AnimeSR CUDA path ~7% (bit-identical)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Bumped `barflow` `0.4.0` → `0.4.1`.
 - Frame-processing loops (main pipeline, depth, object detection, segment) now terminate on the decoder's end-of-stream sentinel instead of polling queue state every frame; main loop uses a one-frame lookahead instead of queue peeking (#329). Thanks @KRRT7.
 - Bumped `nelux` `0.12.4` → `0.12.7`.
+- AnimeSR (`MSRSWVSR`) CUDA inference path: **~+7% throughput** (RTX 3090, fp16, 360/720/1080p; ~+5–6% fp32) at **bit-identical output**. Removed a model↔input memory-layout mismatch (`channels_last` inputs fed to an NCHW model) that burned ~18% of CUDA time on per-conv layout conversions; dropped the no-op `res_scale == 1` multiply and the 9 `+ 0` multi-scale adds per forward. Peak reserved VRAM unchanged.
 
 ### Fixed
 - `--interpolate_method rife4.16-lite` crashed at model download (`ValueError: Model rife4.16-lite not found.`) — the method was wired through the CLI, model init and the arch table but had no `modelsMap` weight mapping. Mapping added (`rife416_lite.pth` / NCNN zips); new registry drift-guard tests (`tests/test_registryDrift.py`) now enforce the choices ↔ registry ↔ `modelsMap` sync so this class of gap fails tests instead of crashing users.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,7 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Bumped `barflow` `0.4.0` → `0.4.1`.
 - Frame-processing loops (main pipeline, depth, object detection, segment) now terminate on the decoder's end-of-stream sentinel instead of polling queue state every frame; main loop uses a one-frame lookahead instead of queue peeking (#329). Thanks @KRRT7.
 - Bumped `nelux` `0.12.4` → `0.12.7`.
-- AnimeSR (`MSRSWVSR`) CUDA inference path: **~+7% throughput** (RTX 3090, fp16, 360/720/1080p; ~+5–6% fp32) at **bit-identical output**. Removed a model↔input memory-layout mismatch (`channels_last` inputs fed to an NCHW model) that burned ~18% of CUDA time on per-conv layout conversions; dropped the no-op `res_scale == 1` multiply and the 9 `+ 0` multi-scale adds per forward. Peak reserved VRAM unchanged.
 
 ### Fixed
 - `--interpolate_method rife4.16-lite` crashed at model download (`ValueError: Model rife4.16-lite not found.`) — the method was wired through the CLI, model init and the arch table but had no `modelsMap` weight mapping. Mapping added (`rife416_lite.pth` / NCNN zips); new registry drift-guard tests (`tests/test_registryDrift.py`) now enforce the choices ↔ registry ↔ `modelsMap` sync so this class of gap fails tests instead of crashing users.
@@ -25,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - CI test job failed at collection: the registry drift-guard tests import `downloadModels`, which pulled in `barflow` (absent from the minimal CI env) at module level via `progressBarLogic`. The progress-bar import is now lazy inside `downloadAndLog`, so registry-only consumers (`modelsList`/`modelsMap`) import clean.
 
 ### Performance
+- **AnimeSR (`MSRSWVSR`) CUDA inference path ~+7% faster** (RTX 3090, fp16, 360/720/1080p; ~+5–6% fp32) at **bit-identical output**. Removed a model↔input memory-layout mismatch (`channels_last` inputs fed to an NCHW model) that burned ~18% of CUDA time on per-conv layout conversions; dropped the no-op `res_scale == 1` multiply and the 9 `+ 0` multi-scale adds per forward. Peak reserved VRAM unchanged.
 - **Motion blur is faster on CUDA** — only the frames inside the shutter window are interpolated. ~1.5× faster at the default shutter 180, up to ~3× at shutter 90. Output is unchanged; TensorRT/DirectML and shutter 360 are unaffected.
 - **Upscale cold start ~30% faster** (launch → first frame on the CUDA/PyTorch path, e.g. `shufflecugan`; measured ~3.5s → ~2.5s at 720p on an RTX 3090). Output is byte-identical and all backends are unaffected. Five independent startup wins:
   - Made the `torchvision` imports in the vendored spandrel `LaMa`/`RestoreFormer` arches lazy (moved to call-site). The eager architecture registry imported `torchvision` (which drags in `torch._dynamo`, ~1s) at every startup even though the upscale model in use almost never touches those arches (~−740ms).

--- a/src/extraArches/AnimeSR.py
+++ b/src/extraArches/AnimeSR.py
@@ -162,7 +162,7 @@ class RightAlignMSConvResidualBlocks(nn.Module):
                 inp_s1 = inp_s1 + self.up(x_s4, 4)
             x_s1 = self.body_s1_first[i](inp_s1)
             if i >= self.num_block[0] - self.num_block[1]:
-                inp_s2 = x_s2 + self.up(x_s4, 2) if flag_s4 else x_s2
+                inp_s2 = (x_s2 + self.up(x_s4, 2)) if flag_s4 else x_s2
                 x_s2 = self.body_s2_first[i - self.num_block[0] + self.num_block[1]](
                     inp_s2
                 )

--- a/src/extraArches/AnimeSR.py
+++ b/src/extraArches/AnimeSR.py
@@ -59,6 +59,10 @@ class ResidualBlockNoBN(nn.Module):
     def forward(self, x):
         identity = x
         out = self.conv2(self.relu(self.conv1(x)))
+        # res_scale == 1 in this arch -> the multiply is identity; skip the
+        # extra elementwise kernel (bit-identical output).
+        if self.res_scale == 1:
+            return identity + out
         return identity + out * self.res_scale
 
 
@@ -148,14 +152,19 @@ class RightAlignMSConvResidualBlocks(nn.Module):
         flag_s2 = False
         flag_s4 = False
         for i in range(0, self.num_block[0]):
-            x_s1 = self.body_s1_first[i](
-                x_s1
-                + (self.up(x_s2, 2) if flag_s2 else 0)
-                + (self.up(x_s4, 4) if flag_s4 else 0)
-            )
+            # Only add the active multi-scale terms; the original `+ 0` for
+            # inactive scales dispatched a wasted elementwise-add kernel.
+            # Accumulation order is preserved -> bit-identical.
+            inp_s1 = x_s1
+            if flag_s2:
+                inp_s1 = inp_s1 + self.up(x_s2, 2)
+            if flag_s4:
+                inp_s1 = inp_s1 + self.up(x_s4, 4)
+            x_s1 = self.body_s1_first[i](inp_s1)
             if i >= self.num_block[0] - self.num_block[1]:
+                inp_s2 = x_s2 + self.up(x_s4, 2) if flag_s4 else x_s2
                 x_s2 = self.body_s2_first[i - self.num_block[0] + self.num_block[1]](
-                    x_s2 + (self.up(x_s4, 2) if flag_s4 else 0)
+                    inp_s2
                 )
                 flag_s2 = True
             if i >= self.num_block[0] - self.num_block[2]:

--- a/src/upscale/misc.py
+++ b/src/upscale/misc.py
@@ -254,7 +254,7 @@ class AnimeSR:
             ),
             device=checker.device,
             dtype=torch.float16 if self.half else torch.float32,
-        ).to(memory_format=torch.channels_last)
+        )
         self.nextFrame = torch.zeros(
             (
                 1,
@@ -264,11 +264,11 @@ class AnimeSR:
             ),
             device=checker.device,
             dtype=torch.float16 if self.half else torch.float32,
-        ).to(memory_format=torch.channels_last)
+        )
 
         self.dummyOutput = self.prevFrame.new_zeros(
             1, 3, self.height * 4, self.width * 4
-        ).to(memory_format=torch.channels_last)
+        )
 
         # The model has some caching functionality that requires a state
         self.state = self.prevFrame.new_zeros(1, 64, self.height, self.width)
@@ -287,21 +287,17 @@ class AnimeSR:
         if self.firstRun:
             with torch.cuda.stream(self.normStream):
                 self.prevFrame.copy_(
-                    frame.to(dtype=frame.dtype).to(memory_format=torch.channels_last),
+                    frame.to(dtype=frame.dtype),
                     non_blocking=False,
                 )
                 if nextFrame is None:
                     self.nextFrame.copy_(
-                        frame.to(dtype=frame.dtype).to(
-                            memory_format=torch.channels_last
-                        ),
+                        frame.to(dtype=frame.dtype),
                         non_blocking=False,
                     )
                 else:
                     self.nextFrame.copy_(
-                        nextFrame.to(dtype=frame.dtype).to(
-                            memory_format=torch.channels_last
-                        ),
+                        nextFrame.to(dtype=frame.dtype),
                         non_blocking=False,
                     )
             self.normStream.synchronize()
@@ -311,16 +307,12 @@ class AnimeSR:
             with torch.cuda.stream(self.normStream):
                 if nextFrame is None:
                     self.nextFrame.copy_(
-                        frame.to(dtype=frame.dtype).to(
-                            memory_format=torch.channels_last
-                        ),
+                        frame.to(dtype=frame.dtype),
                         non_blocking=False,
                     )
                 else:
                     self.nextFrame.copy_(
-                        nextFrame.to(dtype=frame.dtype).to(
-                            memory_format=torch.channels_last
-                        ),
+                        nextFrame.to(dtype=frame.dtype),
                         non_blocking=False,
                     )
             self.normStream.synchronize()


### PR DESCRIPTION
## Summary
Optimizes the AnimeSR (`MSRSWVSR`) CUDA inference path. **~+7% throughput (fp16), +5–6% (fp32)** at **bit-identical output** — no quality change. Three changes, all algebraically exact:

1. **Layout fix** (`src/upscale/misc.py`, `AnimeSR`): the wrapper forced `channels_last` on the inputs while the model stayed NCHW, so activations bounced NHWC↔NCHW around every conv — profiler showed **~18% of CUDA time** in layout-conversion kernels (3750 conversions / 50 iters). Feed contiguous NCHW so the whole forward runs in one layout.
2. **Drop `res_scale == 1` multiply** (`MSRSWVSR.ResidualBlockNoBN`): `identity + out * 1` → `identity + out`. 10 redundant elementwise muls/forward removed.
3. **Remove no-op `+ 0` adds** (`RightAlignMSConvResidualBlocks`): inactive multi-scale terms added a literal `0` each — 9 wasted full-tensor add kernels/forward. Accumulation order preserved.

`src/extraArches/AnimeSR.py` is identical on `main` and `pr352`, so this applies cleanly regardless of the pending refactor PR.

## Measurements (RTX 3090, torch 2.12.0+cu132, in-process interleaved A/B to cancel WDDM boost drift)
| res | prec | baseline FPS | final FPS | Δ total |
|----|----|----|----|----|
| 360p | fp16 | 52.85 | 56.99 | +7.26% |
| 720p | fp16 | 13.07 | 14.13 | +7.55% |
| 1080p | fp16 | 5.67 | 6.09 | +7.01% |
| 360p | fp32 | 15.94 | 16.93 | +5.86% |
| 720p | fp32 | 4.00 | 4.22 | +5.17% |

Layout fix contributes +2–5% (GPU-load dependent), the two op removals a robust ~+5% (reproduced across two harnesses × 3 resolutions). Peak **reserved** VRAM unchanged at every cell.

## Correctness
Deterministic harness over 60 real ordered frames (recurrent model): candidate-vs-original fp16 **max-abs = 0.000000**. pyiqa PSNR/SSIM (Y, BT.601 YCbCr, crop_border=2) vs GT identical (30.5151 / 0.97250, ΔPSNR 0, ΔSSIM 0). NaN/Inf screen clean. The changes are bit-identical, not merely within the FP16 noise floor.

## Scope / notes
- CUDA path only. The shared `MSRSWVSR` arch edits also benefit the TRT export; a native `F.pixel_shuffle`/`pixel_unshuffle` swap was tested, was flat on CUDA, and is deferred to the next TRT engine rebuild.
- Stream-sync skeleton and the 4×→2× bicubic downscale untouched.