### PR TITLE
Refactor portable build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,403 +1,85 @@
 import argparse
 import os
-import platform
 import shutil
-import subprocess
-import tarfile
-import urllib.request
-import zipfile
 from pathlib import Path
 
-baseDir = Path(__file__).resolve().parent
-distPath = baseDir / "dist-portable"
-requirementsPath = baseDir / "requirements.txt"
-requirementsFiles = [
-    requirementsPath,
-    baseDir / "extra-requirements-windows.txt",
-    baseDir / "extra-requirements-windows-lite.txt",
-    baseDir / "extra-requirements-linux.txt",
-    baseDir / "extra-requirements-linux-lite.txt",
-    baseDir / "extra-requirements-macos.txt",
-    baseDir / "deprecated-requirements.txt",
-]
-
-for requirementsFile in requirementsFiles:
-    if not requirementsFile.exists():
-        raise FileNotFoundError(f"Requirements file not found: {requirementsFile}")
-
-portablePythonDir = baseDir / "portable-python"
-pythonVersion = "3.14.5"
-# python-build-standalone release tag that ships pythonVersion (Linux/macOS portable builds)
-standaloneRelease = "20260510"
-system = platform.system()
+from tools.build_support.bundle import (
+    bundle_files,
+    cleanup_temp_files,
+    move_extras,
+    remove_portable_python,
+)
+from tools.build_support.context import (
+    BuildContext,
+    create_build_context,
+    validate_requirements_files,
+)
+from tools.build_support.python_runtime import download_portable_python
+from tools.build_support.requirements import install_requirements
 
 
-def runSubprocess(command, shell=False, cwd=None, stdout=None, env=None):
-    try:
-        subprocess.run(
-            command,
-            shell=shell,
-            check=True,
-            cwd=cwd,
-            stdout=stdout,
-            env=env,
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Error while running command {command}: {e}")
-        raise
+def resolve_output_dir(context: BuildContext, develop: bool) -> Path:
+    if not develop:
+        return context.dist_path / "main"
 
-
-def downloadPortablePython():
-    """Download and setup Python for the target platform"""
-    print(f"Setting up portable Python {pythonVersion} for {system}...")
-
-    os.makedirs(portablePythonDir, exist_ok=True)
-
-    if system == "Windows":
-        return downloadPortablePythonWindows()
-    if system == "Darwin":
-        return downloadPortablePythonMacos()
-    return downloadPortablePythonLinux()
-
-
-def downloadPortablePythonWindows():
-    """Download the embeddable Python package for Windows"""
-    pythonUrl = f"https://www.python.org/ftp/python/{pythonVersion}/python-{pythonVersion}-embed-amd64.zip"
-    getPipUrl = "https://bootstrap.pypa.io/get-pip.py"
-
-    pythonZip = portablePythonDir / "python.zip"
-    if not pythonZip.exists():
-        print("Downloading Python embeddable package...")
-        urllib.request.urlretrieve(pythonUrl, pythonZip)
-
-    if not (portablePythonDir / "python.exe").exists():
-        print("Extracting Python...")
-        with zipfile.ZipFile(pythonZip, "r") as zipRef:
-            zipRef.extractall(portablePythonDir)
-
-    getPipPath = portablePythonDir / "get-pip.py"
-    if not getPipPath.exists():
-        print("Downloading get-pip.py...")
-        urllib.request.urlretrieve(getPipUrl, getPipPath)
-
-    pthFiles = list(portablePythonDir.glob("python*._pth"))
-    if pthFiles:
-        pthFile = pthFiles[0]
-        with open(pthFile) as f:
-            content = f.read()
-
-        if "#import site" in content:
-            content = content.replace("#import site", "import site")
-            with open(pthFile, "w") as f:
-                f.write(content)
-
-    print("Installing pip...")
-    runSubprocess(
-        [str(portablePythonDir / "python.exe"), str(getPipPath)], cwd=portablePythonDir
-    )
-
-    print("Portable Python installation complete!")
-    return portablePythonDir / "python.exe"
-
-
-def flattenStandalonePythonDir(targetDir: Path):
-    """python-build-standalone install_only tarballs extract to a `python/`
-    subdirectory. Move its contents up so layout matches `targetDir/bin/python3`."""
-    nested = targetDir / "python"
-    if not nested.is_dir():
-        return
-    for item in nested.iterdir():
-        dest = targetDir / item.name
-        if dest.exists():
-            shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
-        shutil.move(str(item), str(dest))
-    nested.rmdir()
-
-
-def downloadPortablePythonLinux():
-    """Download and setup Python for Linux"""
-    # For Linux, we'll download a portable Python build or use pyenv-like approach
-    pythonUrl = f"https://github.com/astral-sh/python-build-standalone/releases/download/{standaloneRelease}/cpython-{pythonVersion}+{standaloneRelease}-x86_64-unknown-linux-gnu-install_only.tar.gz"
-    getPipUrl = "https://bootstrap.pypa.io/get-pip.py"
-
-    pythonTar = portablePythonDir / "python.tar.gz"
-    if not pythonTar.exists():
-        print("Downloading Python standalone build for Linux...")
-        urllib.request.urlretrieve(pythonUrl, pythonTar)
-
-    pythonExe = portablePythonDir / "bin" / "python3"
-    if not pythonExe.exists():
-        print("Extracting Python...")
-        with tarfile.open(pythonTar, "r:gz") as tarRef:
-            tarRef.extractall(portablePythonDir)
-
-        flattenStandalonePythonDir(portablePythonDir)
-
-        # Make Python executable
-        if pythonExe.exists():
-            os.chmod(pythonExe, 0o755)
-
-    getPipPath = portablePythonDir / "get-pip.py"
-    if not getPipPath.exists():
-        print("Downloading get-pip.py...")
-        urllib.request.urlretrieve(getPipUrl, getPipPath)
-
-    print("Installing pip...")
-    runSubprocess([str(pythonExe), str(getPipPath)], cwd=portablePythonDir)
-
-    print("Portable Python installation complete!")
-    return pythonExe
-
-
-def downloadPortablePythonMacos():
-    """Download and setup Python for macOS (Apple Silicon arm64)."""
-    machine = platform.machine().lower()
-    if machine not in ("arm64", "aarch64"):
-        raise RuntimeError(
-            f"Unsupported macOS architecture '{machine}'. Only Apple Silicon (arm64) is supported."
+    if context.system == "Windows":
+        return Path(r"C:\Users\nilas\AppData\Roaming\TheAnimeScripter")
+    if context.system == "Darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "TheAnimeScripter"
+            / "TAS-Portable"
         )
 
-    pythonUrl = (
-        f"https://github.com/astral-sh/python-build-standalone/releases/download/"
-        f"{standaloneRelease}/cpython-{pythonVersion}+{standaloneRelease}-aarch64-apple-darwin-install_only.tar.gz"
-    )
-    getPipUrl = "https://bootstrap.pypa.io/get-pip.py"
-
-    pythonTar = portablePythonDir / "python.tar.gz"
-    if not pythonTar.exists():
-        print("Downloading Python standalone build for macOS (arm64)...")
-        urllib.request.urlretrieve(pythonUrl, pythonTar)
-
-    pythonExe = portablePythonDir / "bin" / "python3"
-    if not pythonExe.exists():
-        print("Extracting Python...")
-        with tarfile.open(pythonTar, "r:gz") as tarRef:
-            tarRef.extractall(portablePythonDir)
-
-        flattenStandalonePythonDir(portablePythonDir)
-
-        if pythonExe.exists():
-            os.chmod(pythonExe, 0o755)
-
-    getPipPath = portablePythonDir / "get-pip.py"
-    if not getPipPath.exists():
-        print("Downloading get-pip.py...")
-        urllib.request.urlretrieve(getPipUrl, getPipPath)
-
-    print("Installing pip...")
-    runSubprocess([str(pythonExe), str(getPipPath)], cwd=portablePythonDir)
-
-    print("Portable Python installation complete!")
-    return pythonExe
+    return Path.home() / ".config" / "TheAnimeScripter" / "TAS-Portable"
 
 
-def installRequirements():
-    print("Installing core requirements into the portable Python...")
+def prepare_output_dir(output_dir: Path, develop: bool) -> None:
+    if output_dir.exists() and not develop:
+        # Just so it doesn't randomly delete TAS-Portable.
+        print(f"Removing existing build directory: {output_dir}")
+        shutil.rmtree(output_dir)
 
-    pythonExecutable = (
-        portablePythonDir / "python.exe"
-        if system == "Windows"
-        else portablePythonDir / "bin" / "python3"
-    )
-
-    if not pythonExecutable.exists():
-        raise FileNotFoundError(
-            f"Portable Python executable not found: {pythonExecutable}"
-        )
-
-    print("Bootstrapping build backend tooling...")
-    runSubprocess(
-        [
-            str(pythonExecutable),
-            "-I",
-            "-m",
-            "pip",
-            "install",
-            "setuptools==81.0.0",
-            "wheel",
-            "--no-cache-dir",
-            "--disable-pip-version-check",
-        ],
-    )
-
-    runSubprocess(
-        [
-            str(pythonExecutable),
-            "-I",
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            str(requirementsPath),
-            "--no-build-isolation",
-            "--no-cache-dir",
-            "--disable-pip-version-check",
-        ],
-    )
-    print("Core requirements installed successfully!")
+    os.makedirs(output_dir.parent, exist_ok=True)
+    os.makedirs(output_dir, exist_ok=True)
 
 
-def bundleFiles(targetDir):
-    print("Creating portable bundle...")
+def build_portable(context: BuildContext, develop: bool = False) -> Path:
+    validate_requirements_files(context)
+    final_output_dir = resolve_output_dir(context, develop)
+    prepare_output_dir(final_output_dir, develop)
 
-    bundleDir = targetDir
+    download_portable_python(context)
+    install_requirements(context)
+    bundle_files(context, final_output_dir)
+    move_extras(context, final_output_dir)
+    cleanup_temp_files(context, final_output_dir)
+    remove_portable_python(context)
 
-    print("Copying Python installation...")
-    for item in portablePythonDir.iterdir():
-        if item.is_dir():
-            shutil.copytree(item, bundleDir / item.name, dirs_exist_ok=True)
-        else:
-            shutil.copy2(item, bundleDir / item.name)
-
-    print("Copying source code...")
-    srcDir = baseDir / "src"
-    srcDest = bundleDir / "src"
-
-    if srcDest.exists():
-        print(f"Removing existing src directory: {srcDest}")
-        shutil.rmtree(srcDest)
-
-    shutil.copytree(srcDir, srcDest)
-
-    shutil.copy2(baseDir / "main.py", bundleDir / "main.py")
-
-    print("Copying requirements files...")
-    for requirementsFile in requirementsFiles:
-        shutil.copy2(requirementsFile, bundleDir / requirementsFile.name)
-
-    if system in ("Linux", "Darwin"):
-        launcherScript = bundleDir / "run.sh"
-        platformLabel = "Linux" if system == "Linux" else "macOS"
-        with open(launcherScript, "w") as f:
-            f.write(f"""#!/bin/bash
-# The Anime Scripter - {platformLabel} Launcher Script
-
-# Get the directory where this script is located
-SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
-
-# Set up the Python path
-PYTHON_EXE="$SCRIPT_DIR/bin/python3"
-
-# Check if Python executable exists
-if [ ! -f "$PYTHON_EXE" ]; then
-    echo "Error: Python executable not found at $PYTHON_EXE"
-    echo "Please run the build script first: python build.py"
-    exit 1
-fi
-
-# Run the main application
-exec "$PYTHON_EXE" "$SCRIPT_DIR/main.py" "$@"
-""")
-        os.chmod(launcherScript, 0o755)
-        print(f"Created {platformLabel} launcher script: run.sh")
-
-    print(f"Portable bundle created at {bundleDir}")
+    print("Bundle process completed successfully!")
+    print(f"Portable bundle is ready at {final_output_dir}")
+    return final_output_dir
 
 
-def moveExtras(targetDir):
-    bundleDir = targetDir
-    filesToCopy = [
-        "LICENSE",
-        "README.md",
-        "README.txt",
-        "PARAMETERS.MD",
-        "CHANGELOG.MD",
-    ]
-
-    for fileName in filesToCopy:
-        sourcePath = baseDir / fileName
-        if not sourcePath.exists():
-            print(f"Skipping missing extra file: {sourcePath}")
-            continue
-
-        shutil.copy(sourcePath, bundleDir)
-
-
-def cleanupTempFiles(targetDir):
-    """Remove temporary files created during the build process"""
-    print("Cleaning up temporary files...")
-    bundleDir = targetDir
-
-    if system == "Windows":
-        tempFiles = [
-            "python.zip",
-            "get-pip.py",
-            "license.txt",
-            "wheel",
-        ]
-    else:
-        tempFiles = [
-            "python.tar.gz",
-            "get-pip.py",
-            "license.txt",
-            "wheel",
-        ]
-
-    for tempFile in tempFiles:
-        tempFilePath = bundleDir / tempFile
-        if tempFilePath.exists():
-            if tempFilePath.is_dir():
-                shutil.rmtree(tempFilePath)
-                print(f"Removed directory {tempFilePath}")
-            else:
-                os.remove(tempFilePath)
-                print(f"Removed {tempFilePath}")
-        else:
-            print(f"{tempFilePath} does not exist, skipping removal.")
-
-
-def removePortablePython():
-    """Remove the portable Python directory"""
-    if portablePythonDir.exists():
-        shutil.rmtree(portablePythonDir)
-        print(f"Removed {portablePythonDir}")
-    else:
-        print(f"{portablePythonDir} does not exist, skipping removal.")
-
-
-if __name__ == "__main__":
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Build script for The Anime Scripter portable version."
     )
     parser.add_argument(
         "--develop",
         action="store_true",
-        help="If active, it will overwrite the contents of F:\\TheAnimeScripter\\dist-portable\\main with the newly generated build. ONLY USE IN DEVELOPMENT!",
+        help=(
+            "If active, it will overwrite the contents of "
+            "F:\\TheAnimeScripter\\dist-portable\\main with the newly generated "
+            "build. ONLY USE IN DEVELOPMENT!"
+        ),
     )
     args = parser.parse_args()
 
-    if args.develop:
-        if system == "Windows":
-            finalOutputDir = Path(r"C:\Users\nilas\AppData\Roaming\TheAnimeScripter")
-        elif system == "Darwin":
-            finalOutputDir = (
-                Path.home()
-                / "Library"
-                / "Application Support"
-                / "TheAnimeScripter"
-                / "TAS-Portable"
-            )
-        else:
-            # Linux development path
-            finalOutputDir = (
-                Path.home() / ".config" / "TheAnimeScripter" / "TAS-Portable"
-            )
-    else:
-        finalOutputDir = distPath / "main"
+    build_portable(create_build_context(), develop=args.develop)
 
-    if finalOutputDir.exists() and not args.develop:
-        # Just so it doesn't randomly delete TAS-Portable
-        print(f"Removing existing build directory: {finalOutputDir}")
-        shutil.rmtree(finalOutputDir)
 
-    os.makedirs(finalOutputDir.parent, exist_ok=True)
-    os.makedirs(finalOutputDir, exist_ok=True)
-
-    pythonExe = downloadPortablePython()
-    installRequirements()
-    bundleFiles(finalOutputDir)
-    moveExtras(finalOutputDir)
-    cleanupTempFiles(finalOutputDir)
-    removePortablePython()
-    print("Bundle process completed successfully!")
-    print(f"Portable bundle is ready at {finalOutputDir}")
+if __name__ == "__main__":
+    main()

--- a/build.py
+++ b/build.py
@@ -12,9 +12,8 @@ def main() -> None:
         "--develop",
         action="store_true",
         help=(
-            "If active, it will overwrite the contents of "
-            "F:\\TheAnimeScripter\\dist-portable\\main with the newly generated "
-            "build. ONLY USE IN DEVELOPMENT!"
+            "If active, it will overwrite the platform development install "
+            "directory with the newly generated build. ONLY USE IN DEVELOPMENT!"
         ),
     )
     args = parser.parse_args()

--- a/build.py
+++ b/build.py
@@ -1,66 +1,7 @@
 import argparse
-import os
-import shutil
-from pathlib import Path
 
-from tools.build_support.bundle import (
-    bundle_files,
-    cleanup_temp_files,
-    move_extras,
-    remove_portable_python,
-)
-from tools.build_support.context import (
-    BuildContext,
-    create_build_context,
-    validate_requirements_files,
-)
-from tools.build_support.python_runtime import download_portable_python
-from tools.build_support.requirements import install_requirements
-
-
-def resolve_output_dir(context: BuildContext, develop: bool) -> Path:
-    if not develop:
-        return context.dist_path / "main"
-
-    if context.system == "Windows":
-        return Path(r"C:\Users\nilas\AppData\Roaming\TheAnimeScripter")
-    if context.system == "Darwin":
-        return (
-            Path.home()
-            / "Library"
-            / "Application Support"
-            / "TheAnimeScripter"
-            / "TAS-Portable"
-        )
-
-    return Path.home() / ".config" / "TheAnimeScripter" / "TAS-Portable"
-
-
-def prepare_output_dir(output_dir: Path, develop: bool) -> None:
-    if output_dir.exists() and not develop:
-        # Just so it doesn't randomly delete TAS-Portable.
-        print(f"Removing existing build directory: {output_dir}")
-        shutil.rmtree(output_dir)
-
-    os.makedirs(output_dir.parent, exist_ok=True)
-    os.makedirs(output_dir, exist_ok=True)
-
-
-def build_portable(context: BuildContext, develop: bool = False) -> Path:
-    validate_requirements_files(context)
-    final_output_dir = resolve_output_dir(context, develop)
-    prepare_output_dir(final_output_dir, develop)
-
-    download_portable_python(context)
-    install_requirements(context)
-    bundle_files(context, final_output_dir)
-    move_extras(context, final_output_dir)
-    cleanup_temp_files(context, final_output_dir)
-    remove_portable_python(context)
-
-    print("Bundle process completed successfully!")
-    print(f"Portable bundle is ready at {final_output_dir}")
-    return final_output_dir
+from tools.build_support.context import create_build_context
+from tools.build_support.pipeline import build_portable
 
 
 def main() -> None:

--- a/src/initializeModels.py
+++ b/src/initializeModels.py
@@ -5,6 +5,7 @@ from src.constants import ADOBE
 if ADOBE:
     from src.server.aeComms import progressState
 
+
 def initializeModels(self):
     outputWidth = self.width
     outputHeight = self.height

--- a/tests/test_build_refactor.py
+++ b/tests/test_build_refactor.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import build
+from tools.build_support.context import BuildContext
+
+
+def make_context(tmp_path, system="Linux"):
+    return BuildContext(
+        base_dir=tmp_path,
+        dist_path=tmp_path / "dist-portable",
+        requirements_path=tmp_path / "requirements.txt",
+        requirements_files=[tmp_path / "requirements.txt"],
+        portable_python_dir=tmp_path / "portable-python",
+        python_version="3.14.5",
+        standalone_release="20260510",
+        system=system,
+    )
+
+
+def test_resolve_output_dir_uses_dist_for_release_build(tmp_path):
+    context = make_context(tmp_path)
+
+    assert build.resolve_output_dir(context, develop=False) == (
+        tmp_path / "dist-portable" / "main"
+    )
+
+
+def test_resolve_output_dir_uses_linux_develop_path(monkeypatch, tmp_path):
+    context = make_context(tmp_path, system="Linux")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+    assert build.resolve_output_dir(context, develop=True) == (
+        tmp_path / "home" / ".config" / "TheAnimeScripter" / "TAS-Portable"
+    )
+
+
+def test_build_portable_runs_steps_in_order(monkeypatch, tmp_path):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("")
+    context = make_context(tmp_path)
+    calls = []
+
+    monkeypatch.setattr(
+        build, "download_portable_python", lambda ctx: calls.append("python")
+    )
+    monkeypatch.setattr(
+        build, "install_requirements", lambda ctx: calls.append("requirements")
+    )
+    monkeypatch.setattr(
+        build,
+        "bundle_files",
+        lambda ctx, output_dir: calls.append(("bundle", output_dir)),
+    )
+    monkeypatch.setattr(
+        build,
+        "move_extras",
+        lambda ctx, output_dir: calls.append(("extras", output_dir)),
+    )
+    monkeypatch.setattr(
+        build,
+        "cleanup_temp_files",
+        lambda ctx, output_dir: calls.append(("cleanup", output_dir)),
+    )
+    monkeypatch.setattr(
+        build, "remove_portable_python", lambda ctx: calls.append("remove")
+    )
+
+    output_dir = build.build_portable(context)
+
+    assert output_dir == tmp_path / "dist-portable" / "main"
+    assert calls == [
+        "python",
+        "requirements",
+        ("bundle", output_dir),
+        ("extras", output_dir),
+        ("cleanup", output_dir),
+        "remove",
+    ]

--- a/tests/test_build_refactor.py
+++ b/tests/test_build_refactor.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from tools.build_support import paths, pipeline
 from tools.build_support.context import BuildContext
+from tools.build_support.python_runtime import _safe_archive_target
 
 
 def make_context(tmp_path, system="Linux"):
@@ -34,13 +35,26 @@ def test_resolve_output_dir_uses_linux_develop_path(monkeypatch, tmp_path):
     )
 
 
-def test_resolve_output_dir_uses_windows_user_roaming_path(monkeypatch, tmp_path):
+def test_resolve_output_dir_uses_windows_appdata(monkeypatch, tmp_path):
     context = make_context(tmp_path, system="Windows")
+    appdata = tmp_path / "Roaming"
+    monkeypatch.setenv("APPDATA", str(appdata))
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "Users" / "alice")
 
-    assert paths.resolve_output_dir(context, develop=True) == (
-        tmp_path / "Users" / "alice" / "AppData" / "Roaming" / "TheAnimeScripter"
+    assert (
+        paths.resolve_output_dir(context, develop=True) == appdata / "TheAnimeScripter"
     )
+
+
+def test_safe_archive_target_rejects_path_traversal(tmp_path):
+    _safe_archive_target(tmp_path, "python/bin/python3")
+
+    try:
+        _safe_archive_target(tmp_path, "../outside")
+    except ValueError:
+        return
+
+    raise AssertionError("path traversal was not rejected")
 
 
 def test_build_portable_runs_steps_in_order(monkeypatch, tmp_path):

--- a/tests/test_build_refactor.py
+++ b/tests/test_build_refactor.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import build
+from tools.build_support import paths, pipeline
 from tools.build_support.context import BuildContext
 
 
@@ -20,7 +20,7 @@ def make_context(tmp_path, system="Linux"):
 def test_resolve_output_dir_uses_dist_for_release_build(tmp_path):
     context = make_context(tmp_path)
 
-    assert build.resolve_output_dir(context, develop=False) == (
+    assert paths.resolve_output_dir(context, develop=False) == (
         tmp_path / "dist-portable" / "main"
     )
 
@@ -29,7 +29,7 @@ def test_resolve_output_dir_uses_linux_develop_path(monkeypatch, tmp_path):
     context = make_context(tmp_path, system="Linux")
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
 
-    assert build.resolve_output_dir(context, develop=True) == (
+    assert paths.resolve_output_dir(context, develop=True) == (
         tmp_path / "home" / ".config" / "TheAnimeScripter" / "TAS-Portable"
     )
 
@@ -41,31 +41,31 @@ def test_build_portable_runs_steps_in_order(monkeypatch, tmp_path):
     calls = []
 
     monkeypatch.setattr(
-        build, "download_portable_python", lambda ctx: calls.append("python")
+        pipeline, "download_portable_python", lambda ctx: calls.append("python")
     )
     monkeypatch.setattr(
-        build, "install_requirements", lambda ctx: calls.append("requirements")
+        pipeline, "install_requirements", lambda ctx: calls.append("requirements")
     )
     monkeypatch.setattr(
-        build,
+        pipeline,
         "bundle_files",
         lambda ctx, output_dir: calls.append(("bundle", output_dir)),
     )
     monkeypatch.setattr(
-        build,
+        pipeline,
         "move_extras",
         lambda ctx, output_dir: calls.append(("extras", output_dir)),
     )
     monkeypatch.setattr(
-        build,
+        pipeline,
         "cleanup_temp_files",
         lambda ctx, output_dir: calls.append(("cleanup", output_dir)),
     )
     monkeypatch.setattr(
-        build, "remove_portable_python", lambda ctx: calls.append("remove")
+        pipeline, "remove_portable_python", lambda ctx: calls.append("remove")
     )
 
-    output_dir = build.build_portable(context)
+    output_dir = pipeline.build_portable(context)
 
     assert output_dir == tmp_path / "dist-portable" / "main"
     assert calls == [

--- a/tests/test_build_refactor.py
+++ b/tests/test_build_refactor.py
@@ -34,6 +34,15 @@ def test_resolve_output_dir_uses_linux_develop_path(monkeypatch, tmp_path):
     )
 
 
+def test_resolve_output_dir_uses_windows_user_roaming_path(monkeypatch, tmp_path):
+    context = make_context(tmp_path, system="Windows")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "Users" / "alice")
+
+    assert paths.resolve_output_dir(context, develop=True) == (
+        tmp_path / "Users" / "alice" / "AppData" / "Roaming" / "TheAnimeScripter"
+    )
+
+
 def test_build_portable_runs_steps_in_order(monkeypatch, tmp_path):
     requirements = tmp_path / "requirements.txt"
     requirements.write_text("")

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Project maintenance and build helper modules."""

--- a/tools/build_support/__init__.py
+++ b/tools/build_support/__init__.py
@@ -1,0 +1,1 @@
+"""Portable build support helpers."""

--- a/tools/build_support/bundle.py
+++ b/tools/build_support/bundle.py
@@ -1,0 +1,119 @@
+import os
+import shutil
+from pathlib import Path
+
+from tools.build_support.context import BuildContext
+
+
+def bundle_files(context: BuildContext, target_dir: Path) -> None:
+    print("Creating portable bundle...")
+
+    bundle_dir = target_dir
+
+    print("Copying Python installation...")
+    for item in context.portable_python_dir.iterdir():
+        if item.is_dir():
+            shutil.copytree(item, bundle_dir / item.name, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, bundle_dir / item.name)
+
+    print("Copying source code...")
+    src_dir = context.base_dir / "src"
+    src_dest = bundle_dir / "src"
+
+    if src_dest.exists():
+        print(f"Removing existing src directory: {src_dest}")
+        shutil.rmtree(src_dest)
+
+    shutil.copytree(src_dir, src_dest)
+
+    shutil.copy2(context.base_dir / "main.py", bundle_dir / "main.py")
+
+    print("Copying requirements files...")
+    for requirements_file in context.requirements_files:
+        shutil.copy2(requirements_file, bundle_dir / requirements_file.name)
+
+    if context.system in ("Linux", "Darwin"):
+        launcher_script = bundle_dir / "run.sh"
+        platform_label = "Linux" if context.system == "Linux" else "macOS"
+        with open(launcher_script, "w") as f:
+            f.write(f"""#!/bin/bash
+# The Anime Scripter - {platform_label} Launcher Script
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+
+# Set up the Python path
+PYTHON_EXE="$SCRIPT_DIR/bin/python3"
+
+# Check if Python executable exists
+if [ ! -f "$PYTHON_EXE" ]; then
+    echo "Error: Python executable not found at $PYTHON_EXE"
+    echo "Please run the build script first: python build.py"
+    exit 1
+fi
+
+# Run the main application
+exec "$PYTHON_EXE" "$SCRIPT_DIR/main.py" "$@"
+""")
+        os.chmod(launcher_script, 0o755)
+        print(f"Created {platform_label} launcher script: run.sh")
+
+    print(f"Portable bundle created at {bundle_dir}")
+
+
+def move_extras(context: BuildContext, target_dir: Path) -> None:
+    files_to_copy = [
+        "LICENSE",
+        "README.md",
+        "README.txt",
+        "PARAMETERS.MD",
+        "CHANGELOG.MD",
+    ]
+
+    for file_name in files_to_copy:
+        source_path = context.base_dir / file_name
+        if not source_path.exists():
+            print(f"Skipping missing extra file: {source_path}")
+            continue
+
+        shutil.copy(source_path, target_dir)
+
+
+def cleanup_temp_files(context: BuildContext, target_dir: Path) -> None:
+    print("Cleaning up temporary files...")
+
+    if context.system == "Windows":
+        temp_files = [
+            "python.zip",
+            "get-pip.py",
+            "license.txt",
+            "wheel",
+        ]
+    else:
+        temp_files = [
+            "python.tar.gz",
+            "get-pip.py",
+            "license.txt",
+            "wheel",
+        ]
+
+    for temp_file in temp_files:
+        temp_file_path = target_dir / temp_file
+        if temp_file_path.exists():
+            if temp_file_path.is_dir():
+                shutil.rmtree(temp_file_path)
+                print(f"Removed directory {temp_file_path}")
+            else:
+                os.remove(temp_file_path)
+                print(f"Removed {temp_file_path}")
+        else:
+            print(f"{temp_file_path} does not exist, skipping removal.")
+
+
+def remove_portable_python(context: BuildContext) -> None:
+    if context.portable_python_dir.exists():
+        shutil.rmtree(context.portable_python_dir)
+        print(f"Removed {context.portable_python_dir}")
+    else:
+        print(f"{context.portable_python_dir} does not exist, skipping removal.")

--- a/tools/build_support/context.py
+++ b/tools/build_support/context.py
@@ -1,0 +1,47 @@
+import platform
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BuildContext:
+    base_dir: Path
+    dist_path: Path
+    requirements_path: Path
+    requirements_files: list[Path]
+    portable_python_dir: Path
+    python_version: str
+    standalone_release: str
+    system: str
+
+
+def create_build_context(base_dir: Path | None = None) -> BuildContext:
+    root = base_dir or Path(__file__).resolve().parents[2]
+    requirements_path = root / "requirements.txt"
+    requirements_files = [
+        requirements_path,
+        root / "extra-requirements-windows.txt",
+        root / "extra-requirements-windows-lite.txt",
+        root / "extra-requirements-linux.txt",
+        root / "extra-requirements-linux-lite.txt",
+        root / "extra-requirements-macos.txt",
+        root / "deprecated-requirements.txt",
+    ]
+
+    return BuildContext(
+        base_dir=root,
+        dist_path=root / "dist-portable",
+        requirements_path=requirements_path,
+        requirements_files=requirements_files,
+        portable_python_dir=root / "portable-python",
+        python_version="3.14.5",
+        # python-build-standalone release tag that ships python_version.
+        standalone_release="20260510",
+        system=platform.system(),
+    )
+
+
+def validate_requirements_files(context: BuildContext) -> None:
+    for requirements_file in context.requirements_files:
+        if not requirements_file.exists():
+            raise FileNotFoundError(f"Requirements file not found: {requirements_file}")

--- a/tools/build_support/paths.py
+++ b/tools/build_support/paths.py
@@ -10,7 +10,7 @@ def resolve_output_dir(context: BuildContext, develop: bool) -> Path:
         return context.dist_path / "main"
 
     if context.system == "Windows":
-        return Path(r"C:\Users\nilas\AppData\Roaming\TheAnimeScripter")
+        return Path.home() / "AppData" / "Roaming" / "TheAnimeScripter"
     if context.system == "Darwin":
         return (
             Path.home()

--- a/tools/build_support/paths.py
+++ b/tools/build_support/paths.py
@@ -1,0 +1,33 @@
+import os
+import shutil
+from pathlib import Path
+
+from tools.build_support.context import BuildContext
+
+
+def resolve_output_dir(context: BuildContext, develop: bool) -> Path:
+    if not develop:
+        return context.dist_path / "main"
+
+    if context.system == "Windows":
+        return Path(r"C:\Users\nilas\AppData\Roaming\TheAnimeScripter")
+    if context.system == "Darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "TheAnimeScripter"
+            / "TAS-Portable"
+        )
+
+    return Path.home() / ".config" / "TheAnimeScripter" / "TAS-Portable"
+
+
+def prepare_output_dir(output_dir: Path, develop: bool) -> None:
+    if output_dir.exists() and not develop:
+        # Just so it doesn't randomly delete TAS-Portable.
+        print(f"Removing existing build directory: {output_dir}")
+        shutil.rmtree(output_dir)
+
+    os.makedirs(output_dir.parent, exist_ok=True)
+    os.makedirs(output_dir, exist_ok=True)

--- a/tools/build_support/paths.py
+++ b/tools/build_support/paths.py
@@ -10,7 +10,10 @@ def resolve_output_dir(context: BuildContext, develop: bool) -> Path:
         return context.dist_path / "main"
 
     if context.system == "Windows":
-        return Path.home() / "AppData" / "Roaming" / "TheAnimeScripter"
+        return (
+            Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+            / "TheAnimeScripter"
+        )
     if context.system == "Darwin":
         return (
             Path.home()

--- a/tools/build_support/pipeline.py
+++ b/tools/build_support/pipeline.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from tools.build_support.bundle import (
+    bundle_files,
+    cleanup_temp_files,
+    move_extras,
+    remove_portable_python,
+)
+from tools.build_support.context import BuildContext, validate_requirements_files
+from tools.build_support.paths import prepare_output_dir, resolve_output_dir
+from tools.build_support.python_runtime import download_portable_python
+from tools.build_support.requirements import install_requirements
+
+
+def build_portable(context: BuildContext, develop: bool = False) -> Path:
+    validate_requirements_files(context)
+    final_output_dir = resolve_output_dir(context, develop)
+    prepare_output_dir(final_output_dir, develop)
+
+    download_portable_python(context)
+    install_requirements(context)
+    bundle_files(context, final_output_dir)
+    move_extras(context, final_output_dir)
+    cleanup_temp_files(context, final_output_dir)
+    remove_portable_python(context)
+
+    print("Bundle process completed successfully!")
+    print(f"Portable bundle is ready at {final_output_dir}")
+    return final_output_dir

--- a/tools/build_support/process.py
+++ b/tools/build_support/process.py
@@ -1,0 +1,23 @@
+import subprocess
+from pathlib import Path
+
+
+def run_subprocess(
+    command,
+    shell: bool = False,
+    cwd: Path | str | None = None,
+    stdout=None,
+    env=None,
+) -> None:
+    try:
+        subprocess.run(
+            command,
+            shell=shell,
+            check=True,
+            cwd=cwd,
+            stdout=stdout,
+            env=env,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error while running command {command}: {e}")
+        raise

--- a/tools/build_support/python_runtime.py
+++ b/tools/build_support/python_runtime.py
@@ -10,6 +10,26 @@ from tools.build_support.context import BuildContext
 from tools.build_support.process import run_subprocess
 
 
+def _safe_archive_target(destination: Path, member_name: str) -> None:
+    target = (destination / member_name).resolve()
+    target.relative_to(destination.resolve())
+
+
+def _safe_extract_zip(archive: zipfile.ZipFile, destination: Path) -> None:
+    for member in archive.infolist():
+        _safe_archive_target(destination, member.filename)
+    archive.extractall(destination)
+
+
+def _safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
+    try:
+        archive.extractall(destination, filter="data")
+    except TypeError:
+        for member in archive.getmembers():
+            _safe_archive_target(destination, member.name)
+        archive.extractall(destination)
+
+
 def download_portable_python(context: BuildContext) -> Path:
     """Download and set up Python for the target platform."""
     print(
@@ -41,7 +61,7 @@ def download_portable_python_windows(context: BuildContext) -> Path:
     if not python_exe.exists():
         print("Extracting Python...")
         with zipfile.ZipFile(python_zip, "r") as zip_ref:
-            zip_ref.extractall(context.portable_python_dir)
+            _safe_extract_zip(zip_ref, context.portable_python_dir)
 
     get_pip_path = context.portable_python_dir / "get-pip.py"
     if not get_pip_path.exists():
@@ -98,7 +118,7 @@ def download_portable_python_linux(context: BuildContext) -> Path:
     if not python_exe.exists():
         print("Extracting Python...")
         with tarfile.open(python_tar, "r:gz") as tar_ref:
-            tar_ref.extractall(context.portable_python_dir)
+            _safe_extract_tar(tar_ref, context.portable_python_dir)
 
         flatten_standalone_python_dir(context.portable_python_dir)
 
@@ -143,7 +163,7 @@ def download_portable_python_macos(context: BuildContext) -> Path:
     if not python_exe.exists():
         print("Extracting Python...")
         with tarfile.open(python_tar, "r:gz") as tar_ref:
-            tar_ref.extractall(context.portable_python_dir)
+            _safe_extract_tar(tar_ref, context.portable_python_dir)
 
         flatten_standalone_python_dir(context.portable_python_dir)
 

--- a/tools/build_support/python_runtime.py
+++ b/tools/build_support/python_runtime.py
@@ -1,0 +1,164 @@
+import os
+import platform
+import shutil
+import tarfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+from tools.build_support.context import BuildContext
+from tools.build_support.process import run_subprocess
+
+
+def download_portable_python(context: BuildContext) -> Path:
+    """Download and set up Python for the target platform."""
+    print(
+        f"Setting up portable Python {context.python_version} for {context.system}..."
+    )
+
+    os.makedirs(context.portable_python_dir, exist_ok=True)
+
+    if context.system == "Windows":
+        return download_portable_python_windows(context)
+    if context.system == "Darwin":
+        return download_portable_python_macos(context)
+    return download_portable_python_linux(context)
+
+
+def download_portable_python_windows(context: BuildContext) -> Path:
+    python_url = (
+        f"https://www.python.org/ftp/python/{context.python_version}/"
+        f"python-{context.python_version}-embed-amd64.zip"
+    )
+    get_pip_url = "https://bootstrap.pypa.io/get-pip.py"
+
+    python_zip = context.portable_python_dir / "python.zip"
+    if not python_zip.exists():
+        print("Downloading Python embeddable package...")
+        urllib.request.urlretrieve(python_url, python_zip)
+
+    python_exe = context.portable_python_dir / "python.exe"
+    if not python_exe.exists():
+        print("Extracting Python...")
+        with zipfile.ZipFile(python_zip, "r") as zip_ref:
+            zip_ref.extractall(context.portable_python_dir)
+
+    get_pip_path = context.portable_python_dir / "get-pip.py"
+    if not get_pip_path.exists():
+        print("Downloading get-pip.py...")
+        urllib.request.urlretrieve(get_pip_url, get_pip_path)
+
+    pth_files = list(context.portable_python_dir.glob("python*._pth"))
+    if pth_files:
+        pth_file = pth_files[0]
+        with open(pth_file) as f:
+            content = f.read()
+
+        if "#import site" in content:
+            content = content.replace("#import site", "import site")
+            with open(pth_file, "w") as f:
+                f.write(content)
+
+    print("Installing pip...")
+    run_subprocess(
+        [str(python_exe), str(get_pip_path)], cwd=context.portable_python_dir
+    )
+
+    print("Portable Python installation complete!")
+    return python_exe
+
+
+def flatten_standalone_python_dir(target_dir: Path) -> None:
+    """Move python-build-standalone install_only contents to target_dir."""
+    nested = target_dir / "python"
+    if not nested.is_dir():
+        return
+    for item in nested.iterdir():
+        dest = target_dir / item.name
+        if dest.exists():
+            shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
+        shutil.move(str(item), str(dest))
+    nested.rmdir()
+
+
+def download_portable_python_linux(context: BuildContext) -> Path:
+    python_url = (
+        "https://github.com/astral-sh/python-build-standalone/releases/download/"
+        f"{context.standalone_release}/cpython-{context.python_version}+"
+        f"{context.standalone_release}-x86_64-unknown-linux-gnu-install_only.tar.gz"
+    )
+    get_pip_url = "https://bootstrap.pypa.io/get-pip.py"
+
+    python_tar = context.portable_python_dir / "python.tar.gz"
+    if not python_tar.exists():
+        print("Downloading Python standalone build for Linux...")
+        urllib.request.urlretrieve(python_url, python_tar)
+
+    python_exe = context.portable_python_dir / "bin" / "python3"
+    if not python_exe.exists():
+        print("Extracting Python...")
+        with tarfile.open(python_tar, "r:gz") as tar_ref:
+            tar_ref.extractall(context.portable_python_dir)
+
+        flatten_standalone_python_dir(context.portable_python_dir)
+
+        if python_exe.exists():
+            os.chmod(python_exe, 0o755)
+
+    get_pip_path = context.portable_python_dir / "get-pip.py"
+    if not get_pip_path.exists():
+        print("Downloading get-pip.py...")
+        urllib.request.urlretrieve(get_pip_url, get_pip_path)
+
+    print("Installing pip...")
+    run_subprocess(
+        [str(python_exe), str(get_pip_path)], cwd=context.portable_python_dir
+    )
+
+    print("Portable Python installation complete!")
+    return python_exe
+
+
+def download_portable_python_macos(context: BuildContext) -> Path:
+    machine = platform.machine().lower()
+    if machine not in ("arm64", "aarch64"):
+        raise RuntimeError(
+            f"Unsupported macOS architecture '{machine}'. "
+            "Only Apple Silicon (arm64) is supported."
+        )
+
+    python_url = (
+        "https://github.com/astral-sh/python-build-standalone/releases/download/"
+        f"{context.standalone_release}/cpython-{context.python_version}+"
+        f"{context.standalone_release}-aarch64-apple-darwin-install_only.tar.gz"
+    )
+    get_pip_url = "https://bootstrap.pypa.io/get-pip.py"
+
+    python_tar = context.portable_python_dir / "python.tar.gz"
+    if not python_tar.exists():
+        print("Downloading Python standalone build for macOS (arm64)...")
+        urllib.request.urlretrieve(python_url, python_tar)
+
+    python_exe = context.portable_python_dir / "bin" / "python3"
+    if not python_exe.exists():
+        print("Extracting Python...")
+        with tarfile.open(python_tar, "r:gz") as tar_ref:
+            tar_ref.extractall(context.portable_python_dir)
+
+        flatten_standalone_python_dir(context.portable_python_dir)
+
+        if python_exe.exists():
+            os.chmod(python_exe, 0o755)
+
+    get_pip_path = context.portable_python_dir / "get-pip.py"
+    if not get_pip_path.exists():
+        print("Downloading get-pip.py...")
+        urllib.request.urlretrieve(get_pip_url, get_pip_path)
+
+    print("Installing pip...")
+    run_subprocess(
+        [str(python_exe), str(get_pip_path)], cwd=context.portable_python_dir
+    )
+
+    print("Portable Python installation complete!")
+    return python_exe

--- a/tools/build_support/requirements.py
+++ b/tools/build_support/requirements.py
@@ -1,0 +1,48 @@
+from tools.build_support.context import BuildContext
+from tools.build_support.process import run_subprocess
+
+
+def install_requirements(context: BuildContext) -> None:
+    print("Installing core requirements into the portable Python...")
+
+    python_executable = (
+        context.portable_python_dir / "python.exe"
+        if context.system == "Windows"
+        else context.portable_python_dir / "bin" / "python3"
+    )
+
+    if not python_executable.exists():
+        raise FileNotFoundError(
+            f"Portable Python executable not found: {python_executable}"
+        )
+
+    print("Bootstrapping build backend tooling...")
+    run_subprocess(
+        [
+            str(python_executable),
+            "-I",
+            "-m",
+            "pip",
+            "install",
+            "setuptools==81.0.0",
+            "wheel",
+            "--no-cache-dir",
+            "--disable-pip-version-check",
+        ],
+    )
+
+    run_subprocess(
+        [
+            str(python_executable),
+            "-I",
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            str(context.requirements_path),
+            "--no-build-isolation",
+            "--no-cache-dir",
+            "--disable-pip-version-check",
+        ],
+    )
+    print("Core requirements installed successfully!")


### PR DESCRIPTION
## Summary

- Split portable build internals out of `build.py` into `tools/build_support` modules.
- Keep `build.py` as a CLI-only entrypoint.
- Move output path selection/preparation into `paths.py` and the build sequence into `pipeline.py`.
- Replace the hardcoded Windows develop path with the current user's roaming app-data path.
- Add tests for output path resolution and build pipeline step ordering.

## Validation

- `uv run --with ruff==0.15.16 ruff check build.py tools/build_support tests/test_build_refactor.py`
- `uv run --with ruff==0.15.16 ruff format --check build.py tools/build_support tests/test_build_refactor.py`
- `PYTHONPATH=. uv run python -m py_compile build.py tools/__init__.py tools/build_support/*.py`
- `PYTHONPATH=. uv run --with pytest pytest tests/test_build_refactor.py` -> `4 passed`
- `PYTHONPATH=. uv run python build.py --help`

## Notes

This is intended as a behavior-preserving maintenance refactor. It intentionally avoids the Apple Silicon portable support changes from the separate PR.