### PR TITLE
feat: scene-cut-aware interpolation (--scenechange)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - YYYY-MM-DD
+### Added
+- Scene-cut-aware interpolation (`--scenechange`, opt-in): a per-frame-pair detector holds the frame at hard cuts instead of letting RIFE morph across them (inspired by vs-rife `sc`). `--scenechange_method` picks the detector — cheap `ssim`/`mse` or the `maxxvit` classifier (shared with the autoclip prepass) — and `--scenechange_sens` the threshold. Drives a unified `cacheFrameReset` across all interpolation backends; output frame count is unchanged.
+
 ### Changed
 - Bumped TensorRT `10.16.1.11` -> `11.1.0.106` in the full Windows/Linux requirement profiles, switching from the hosted cp314 wheels to NVIDIA's current PyPI metapackage. TensorRT imports now go through a small compatibility helper so the code works with both the traditional `tensorrt` API module and the TensorRT 11.1 cp314 layout that exposes the API through `tensorrt_bindings`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ python build.py
 | Segment | `src/segment/animeSegment.py` | CUDA, TRT, DML, OpenVINO |
 | Object detect | `src/objectDetection/objectDetection.py` | CUDA, TRT, DML |
 | Autoclip | `src/autoclip/` | PySceneDetect CPU, TRT, DML, TransNetV2 |
+| Scene-cut (interp) | `src/sceneChange/` | streaming per-pair cut detector for `--scenechange`; ssim/mse + maxxvit 6ch (shared `scorer6ch.py`); holds instead of morphing across cuts |
 | Stabilize | `src/stabilize/` | SuperPoint with ORB/LK fallback |
 | Motion blur | `src/motionBlur.py` | `MotionBlurPipeline` |
 
@@ -47,6 +48,7 @@ URL input is handled by `src/ytdlp.py`.
 - OpenVINO is normally handled inside the DirectML/ORT class; only Segment has `AnimeSegmentOpenVino`. Model-specific exceptions include `AnimeSR*`, `ArtCNN*`, `DistilDRBA*`, `NvidiaVSR`, and `DepthGuidedRife*`.
 - Weights: `modelsMap()` resolves name/scale/dtype; `resolveWeightPath()` uses `weights/{model}/`. TRT/DML/OpenVINO use `weights/{model}-onnx/`, except RIFE keeps its base folder. Downloads come from TAS-Models-Host.
 - Output naming: `src/io/inputOutputHandler.py:generateOutputName()`; encoders: `src/io/encodingSettings.py:matchEncoder()` plus mirrored CLI choices.
+- Scene-cut skip (`--scenechange`): `main.py:processFrame` runs a `src/sceneChange/` detector; on a cut it emits held frames and calls `interpolate_process.cacheFrameReset(frame)`. One contract across ALL interp backends: re-anchor `I0=frame`, re-seed encoder feature, keep `firstRun` false. GRAPH/binding-safe on `RifeCuda`/`RifeTensorRT` — re-seed `I0`/`f0` in-place, never reassign (arch `cacheReset` reassigns `f0` → would break CUDA-graph replay). Only the (nonexistent) `DepthGuidedRifeCuda` lacks the hook.
 - ONNX export: `tools/onnxConverter.py`; TensorRT engine build/cache: `src/model/trtHandler.py`.
 - Global runtime state: `src/constants.py` (`WHEREAMIRUNFROM`, `SYSTEM`, `FFMPEGPATH`, `FFPROBEPATH`, `METADATAPATH`, `ADOBE`, `AUDIO`), initialized by CLI startup/validation and imported as `cs`.
 - Dependencies/FFmpeg/hardware: `src/infra/{dependencyHandler,getFFMPEG,checkSpecs}.py`.

--- a/PARAMETERS.MD
+++ b/PARAMETERS.MD
@@ -346,6 +346,18 @@ C:\Videos\episode3.mp4
 | `--static_step` | flag | False | **Static timestep** - Force static timestep for RIFE CUDA |
 | `--interpolate_first` | bool | True | **Processing order** - Write interpolated frames to queue immediately |
 
+#### ✂️ Scene-Cut-Aware Interpolation
+
+Interpolating across a hard scene cut produces a melt/ghost frame. When enabled, TAS detects the cut and **holds** (duplicates) the frame instead of morphing across it. Opt-in; off by default; output frame count is unchanged.
+
+| Parameter | Type | Default | Range | Description |
+|-----------|------|---------|-------|-------------|
+| `--scenechange` | flag | False | - | **Skip interpolation across hard cuts** (requires `--interpolate`) |
+| `--scenechange_method` | str | "ssim-cuda" | ssim, ssim-cuda, mse, mse-cuda, maxxvit-tensorrt, maxxvit-directml | **Streaming cut detector** — cheap `ssim`/`mse` (no model) or the `maxxvit` classifier |
+| `--scenechange_sens` | float | 50 | 0-100 | **Cut sensitivity** (higher = more cuts detected); mapped to a per-method threshold |
+
+> **Note:** `transnetv2` and `pyscenedetect` are prepass-only (windowed / whole-file) and are not available here — use `--autoclip` for those.
+
 ### 🔄 Deduplication
 
 | Parameter | Type | Default | Range | Description |

--- a/main.py
+++ b/main.py
@@ -164,6 +164,11 @@ class VideoProcessor:
         # Enhancement settings
         self.autoclipSens: float = args.autoclip_sens
         self.autoclipMethod: str = args.autoclip_method
+
+        # Streaming scene-cut skip for the interpolation path (opt-in).
+        self.sceneChange: bool = getattr(args, "scenechange", False)
+        self.sceneChangeMethod: str = getattr(args, "scenechange_method", "ssim-cuda")
+        self.sceneChangeThreshold = getattr(args, "scenechange_threshold", None)
         self.depthQuality: str = args.depth_quality
         self.depthNorm: bool = args.depth_norm
 
@@ -325,10 +330,39 @@ class VideoProcessor:
                 self.framesToInsert = int(self.interpolateFactor) - 1
                 self.timesteps = None
 
+        # Hard-cut detection: if this frame is a scene cut relative to the
+        # previous kept frame, hold (duplicate) instead of morphing across it.
+        # Evaluated on the post-restore frame; the detector downsamples anyway.
+        self._isCut = bool(
+            self.interpolate
+            and self.sceneChange_process is not None
+            and self.sceneChange_process(frame)
+        )
+
         if self.interpolateFirst:
             self.ifInterpolateFirst(frame)
         else:
             self.ifInterpolateLast(frame)
+
+    def _interpolateOrHold(self, frame: any, sink: any) -> None:
+        """
+        Feed the interpolation driver, or on a detected scene cut emit
+        ``framesToInsert`` duplicates of the current frame into ``sink`` and
+        reset the driver's frame/feature cache (via ``cacheFrameReset``) so the
+        next interpolation anchors on this frame with no bleed from the previous
+        scene. ``sink`` is ``self.interpQueue`` (interpolate-first) or
+        ``self.writeBuffer`` (interpolate-last); both expose ``put``.
+        """
+        if self._isCut:
+            for _ in range(self.framesToInsert):
+                sink.put(frame.clone())
+            self.interpolate_process.cacheFrameReset(frame)
+        elif self.interpolateMethod.startswith("distildrba"):
+            self.interpolate_process(
+                frame, self.nextFrame, sink, self.framesToInsert, self.timesteps
+            )
+        else:
+            self.interpolate_process(frame, sink, self.framesToInsert, self.timesteps)
 
     def _drainInterpQueue(self) -> None:
         while True:
@@ -346,18 +380,7 @@ class VideoProcessor:
             frame: Input video frame tensor
         """
         if self.interpolate:
-            if self.interpolateMethod.startswith("distildrba"):
-                self.interpolate_process(
-                    frame,
-                    self.nextFrame,
-                    self.interpQueue,
-                    self.framesToInsert,
-                    self.timesteps,
-                )
-            else:
-                self.interpolate_process(
-                    frame, self.interpQueue, self.framesToInsert, self.timesteps
-                )
+            self._interpolateOrHold(frame, self.interpQueue)
 
         if self.upscale:
             if self.interpolate:
@@ -389,18 +412,7 @@ class VideoProcessor:
             frame = self.upscale_process(frame, self.nextFrame)
 
         if self.interpolate:
-            if self.interpolateMethod.startswith("distildrba"):
-                self.interpolate_process(
-                    frame,
-                    self.nextFrame,
-                    self.writeBuffer,
-                    self.framesToInsert,
-                    self.timesteps,
-                )
-            else:
-                self.interpolate_process(
-                    frame, self.writeBuffer, self.framesToInsert, self.timesteps
-                )
+            self._interpolateOrHold(frame, self.writeBuffer)
 
         self.writeBuffer.write(frame)
 
@@ -513,6 +525,7 @@ class VideoProcessor:
                 self.interpolate_process,
                 self.restore_process,
                 self.dedup_process,
+                self.sceneChange_process,
             ) = initializeModels(self)
 
             starTime: float = time()

--- a/src/autoclip/autoclipMaxxvit.py
+++ b/src/autoclip/autoclipMaxxvit.py
@@ -3,15 +3,17 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 
+# nelux hard-requires torch to be imported first (checked at nelux import time),
+# so torch MUST precede nelux here. Guard the order against isort reordering.
+# isort: off
+import torch  # noqa: F401
 import nelux
-import numpy as np
-import torch
 
+# isort: on
 import src.constants as cs
 from src.infra.logAndPrint import logAndPrint
 from src.infra.progressBarLogic import ProgressBarLogic
-from src.model.download import downloadModels
-from src.model.registry import modelsMap, weightsDir
+from src.sceneChange.scorer6ch import SceneChangeScorer6ch
 
 _SENTINEL = object()
 
@@ -23,9 +25,10 @@ class AutoClipMaxxvit:
     Decoding runs in a dedicated thread via a ``ThreadPoolExecutor``; nelux
     decodes + downscales to 224x224 (libswscale) and pushes torch tensors
     (HWC uint8) into a bounded queue. The main thread runs preprocess +
-    inference. Output index ``[0][0]`` of the model's softmax is the cut
-    probability; cut timestamps (seconds) are written to
-    ``autoclipresults.txt``.
+    inference via the shared ``SceneChangeScorer6ch`` (the same 6-channel
+    classifier used by the streaming interpolation-path detector). Output
+    index ``[0][0]`` of the model's softmax is the cut probability; cut
+    timestamps (seconds) are written to ``autoclipresults.txt``.
     """
 
     H = W = 224
@@ -47,8 +50,9 @@ class AutoClipMaxxvit:
         self.outPoint = outPoint
         self.half = half
 
-        self.backend = "tensorrt" if method.endswith("-tensorrt") else "directml"
-        self._loadModel()
+        # Shared scoring core (model load + preprocess + score). Handles the
+        # TRT-fp32 pin / DML session selection internally.
+        self.scorer = SceneChangeScorer6ch(method, half, size=self.H)
 
         if cs.ADOBE:
             from src.server.aeComms import progressState
@@ -65,146 +69,6 @@ class AutoClipMaxxvit:
             progressState.setCompleted(outputPath=outPath)
         else:
             self._run()
-
-    def _resolveModelPath(self):
-        # TensorRT path is pinned to fp32 weights + fp32 engine because TRT 10.x
-        # lacks an fp16 kernel for the depthwise conv at this shape, and the
-        # model's softmax is numerically unstable in fp16 (saturates).
-        weightHalf = False if self.backend == "tensorrt" else self.half
-        filename = modelsMap(self.method, half=weightHalf, modelType="onnx")
-        folderName = self.method.replace("-tensorrt", "-onnx").replace(
-            "-directml", "-onnx"
-        )
-        modelPath = os.path.join(weightsDir, folderName, filename)
-        if not os.path.exists(modelPath):
-            modelPath = downloadModels(
-                model=self.method, half=weightHalf, modelType="onnx"
-            )
-        return modelPath
-
-    def _loadModel(self):
-        self.modelPath = self._resolveModelPath()
-        if self.backend == "tensorrt":
-            self._loadTensorRT()
-        else:
-            self._loadDirectML()
-
-    def _loadDirectML(self):
-        import onnxruntime as ort
-
-        providers = ort.get_available_providers()
-        if "DmlExecutionProvider" in providers:
-            logging.info("Using DirectML for autoclip MaxxVit inference")
-            self.session = ort.InferenceSession(
-                self.modelPath, providers=["DmlExecutionProvider"]
-            )
-        else:
-            logAndPrint(
-                "DirectML provider not available, falling back to CPU. "
-                "Performance will be significantly worse.",
-                "yellow",
-            )
-            self.session = ort.InferenceSession(
-                self.modelPath, providers=["CPUExecutionProvider"]
-            )
-
-    def _loadTensorRT(self):
-        from src.model.trtHandler import (
-            tensorRTEngineCreator,
-            tensorRTEngineLoader,
-            tensorRTEngineNameHandler,
-        )
-        from src.utils.tensorrt_import import trt
-
-        self.trt = trt
-
-        if self.half:
-            logging.warning(
-                "maxxvit-tensorrt ignores --half: model softmax overflows in fp16. "
-                "Building/using fp32 engine."
-            )
-        useFp16 = False
-
-        enginePath = tensorRTEngineNameHandler(
-            modelPath=self.modelPath,
-            fp16=useFp16,
-            optInputShape=[0, 6, self.H, self.W],
-        )
-
-        engine, context = tensorRTEngineLoader(enginePath)
-        if engine is None or context is None or not os.path.exists(enginePath):
-            engine, context = tensorRTEngineCreator(
-                modelPath=self.modelPath,
-                enginePath=enginePath,
-                fp16=useFp16,
-                inputsMin=[6, self.H, self.W],
-                inputsOpt=[6, self.H, self.W],
-                inputsMax=[6, self.H, self.W],
-            )
-
-        if engine is None or context is None:
-            raise RuntimeError(
-                f"Failed to build/load TensorRT engine for {self.modelPath}"
-            )
-
-        self.engine = engine
-        self.context = context
-
-        self.dType = torch.float32
-        self.device = torch.device("cuda")
-        self.stream = torch.cuda.Stream()
-
-        self.dummyInput = torch.zeros(
-            (6, self.H, self.W), device=self.device, dtype=self.dType
-        )
-        self.dummyOutput = torch.zeros((1, 2), device=self.device, dtype=self.dType)
-
-        bindings = [self.dummyInput.data_ptr(), self.dummyOutput.data_ptr()]
-        for i in range(self.engine.num_io_tensors):
-            tensorName = self.engine.get_tensor_name(i)
-            self.context.set_tensor_address(tensorName, bindings[i])
-            if self.engine.get_tensor_mode(tensorName) == trt.TensorIOMode.INPUT:
-                self.context.set_input_shape(tensorName, self.dummyInput.shape)
-
-        with torch.cuda.stream(self.stream):
-            for _ in range(5):
-                self.context.execute_async_v3(stream_handle=self.stream.cuda_stream)
-            self.stream.synchronize()
-
-        self.cudaGraph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(self.cudaGraph, stream=self.stream):
-            self.context.execute_async_v3(stream_handle=self.stream.cuda_stream)
-        self.stream.synchronize()
-
-    def _preprocessNumpy(self, hwcTensor):
-        """DML: zero-copy torch CPU uint8 -> numpy CHW float [0,1]."""
-        arr = hwcTensor.numpy()
-        arr = arr.astype(np.float16 if self.half else np.float32) / 255.0
-        return np.ascontiguousarray(arr.transpose(2, 0, 1))
-
-    def _preprocessTorch(self, hwcTensor):
-        """TRT: torch CPU uint8 -> CHW fp32 [0,1] on GPU."""
-        with torch.cuda.stream(self.stream):
-            t = (
-                hwcTensor.to(device=self.device, non_blocking=True)
-                .to(self.dType)
-                .div_(255.0)
-                .permute(2, 0, 1)
-            )
-        return t
-
-    def _scoreDirectML(self, prev, curr):
-        inputs = np.concatenate((prev, curr), axis=0)
-        result = self.session.run(None, {"input": inputs})[0]
-        return float(result[0][0])
-
-    def _scoreTensorRT(self, prev, curr):
-        with torch.cuda.stream(self.stream):
-            self.dummyInput.copy_(torch.cat((prev, curr), dim=0), non_blocking=True)
-            self.cudaGraph.replay()
-            score = self.dummyOutput[0][0].item()
-        self.stream.synchronize()
-        return score
 
     def _openReader(self):
         # Linear iter is the fast path. Do NOT switch to ``reader.frame_at(i)``
@@ -257,12 +121,8 @@ class AutoClipMaxxvit:
     def _run(self):
         iterable, fps, startSec, totalFrames = self._openReader()
 
-        if self.backend == "tensorrt":
-            preprocess = self._preprocessTorch
-            score = self._scoreTensorRT
-        else:
-            preprocess = self._preprocessNumpy
-            score = self._scoreDirectML
+        preprocess = self.scorer.preprocessHWC
+        score = self.scorer.score
 
         queue: Queue = Queue(maxsize=self.QUEUE_SIZE)
         cuts = []

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -999,6 +999,34 @@ def _addSceneDetectionOptions(argParser):
     sceneGroup.add_argument(
         "--autoclip_sens", type=float, default=50, help="Autoclip sensitivity"
     )
+    sceneGroup.add_argument(
+        "--scenechange",
+        action="store_true",
+        help="Skip interpolating across hard scene cuts (hold the frame instead "
+        "of morphing across the cut). Requires --interpolate.",
+    )
+    sceneGroup.add_argument(
+        "--scenechange_method",
+        type=str,
+        default="ssim-cuda",
+        choices=[
+            "ssim",
+            "ssim-cuda",
+            "mse",
+            "mse-cuda",
+            "maxxvit-tensorrt",
+            "maxxvit-directml",
+        ],
+        help="Streaming scene-cut detector for --scenechange. Cheap: "
+        "ssim/mse (no model). Classifier: maxxvit-tensorrt/-directml.",
+    )
+    sceneGroup.add_argument(
+        "--scenechange_sens",
+        type=float,
+        default=50,
+        help="Scene-cut sensitivity for --scenechange (0-100, higher = more "
+        "cuts detected). Mapped to a per-method threshold.",
+    )
 
 
 def _addDepthOptions(argParser):

--- a/src/cli/validator.py
+++ b/src/cli/validator.py
@@ -96,6 +96,37 @@ def _configureProcessingSettings(args):
             f"New autoclip sensitivity for {args.autoclip_method} is: {args.autoclip_sens}"
         )
 
+    # Streaming scene-cut skip for the interpolation path. Map the 0-100
+    # sensitivity to a per-method threshold (see src/sceneChange/detector.py for
+    # the compare direction of each metric). Only meaningful with --interpolate.
+    args.scenechange_threshold = None
+    if getattr(args, "scenechange", False):
+        if not args.interpolate:
+            logging.warning(
+                "--scenechange has no effect without --interpolate; disabling it"
+            )
+            args.scenechange = False
+        else:
+            method = args.scenechange_method
+            sens = args.scenechange_sens
+            if method in ("ssim", "ssim-cuda"):
+                # cut when ssim < threshold; higher sensitivity -> higher threshold
+                args.scenechange_threshold = sens / 100.0
+            elif method in ("mse", "mse-cuda"):
+                # cut when mse > threshold; higher sensitivity -> lower threshold
+                args.scenechange_threshold = (100.0 - sens) * 50.0
+            elif method in ("maxxvit-tensorrt", "maxxvit-directml"):
+                # cut when cut-prob > threshold; mirrors autoclip maxxvit mapping
+                args.scenechange_threshold = 1.0 - (sens / 100.0)
+            else:
+                raise ValueError(
+                    f"Unsupported scenechange_method: {method}. "
+                    f"transnetv2/pyscenedetect are prepass-only; use --autoclip."
+                )
+            logging.info(
+                f"scenechange threshold for {method} is: {args.scenechange_threshold}"
+            )
+
     if args.compile_mode != "default":
         logging.info(
             f"Pytorch Compile mode is set to {args.compile_mode}, this will increase startup time and memory usage and may lead to instability with some models"

--- a/src/cli/validator.py
+++ b/src/cli/validator.py
@@ -109,6 +109,27 @@ def _configureProcessingSettings(args):
         else:
             method = args.scenechange_method
             sens = args.scenechange_sens
+            # Device guard: the default (ssim-cuda) and the other CUDA/TensorRT
+            # detectors initialize on torch.device("cuda"); downgrade to a
+            # CPU/DML equivalent when CUDA is unavailable (CPU/MPS boxes) so
+            # enabling --scenechange there does not crash at detector init. The
+            # threshold formula is grouped by metric, so remapping here first is
+            # threshold-neutral.
+            from src.infra.isCudaInit import CudaChecker
+
+            if not CudaChecker().cudaAvailable:
+                downgrade = {
+                    "ssim-cuda": "ssim",
+                    "mse-cuda": "mse",
+                    "maxxvit-tensorrt": "maxxvit-directml",
+                }
+                if method in downgrade:
+                    logging.warning(
+                        f"CUDA unavailable; scenechange_method {method} -> "
+                        f"{downgrade[method]}"
+                    )
+                    method = downgrade[method]
+                    args.scenechange_method = method
             if method in ("ssim", "ssim-cuda"):
                 # cut when ssim < threshold; higher sensitivity -> higher threshold
                 args.scenechange_threshold = sens / 100.0

--- a/src/factories/sceneChange.py
+++ b/src/factories/sceneChange.py
@@ -1,0 +1,43 @@
+"""
+Streaming scene-change detector factory.
+
+buildSceneChangeProcess(self) -> callable(frame) -> bool
+
+Only built when interpolation is enabled and ``--scenechange`` is set. The
+returned callable holds its own reference frame and returns True on a hard cut.
+Mirrors src/factories/dedup.py.
+"""
+
+
+def buildSceneChangeProcess(self):
+    method = self.sceneChangeMethod
+    threshold = self.sceneChangeThreshold
+
+    match method:
+        case "ssim":
+            from src.sceneChange.detector import SceneChangeSSIM
+
+            return SceneChangeSSIM(threshold)
+
+        case "ssim-cuda":
+            from src.sceneChange.detector import SceneChangeSSIMCuda
+
+            return SceneChangeSSIMCuda(threshold, self.half)
+
+        case "mse":
+            from src.sceneChange.detector import SceneChangeMSE
+
+            return SceneChangeMSE(threshold)
+
+        case "mse-cuda":
+            from src.sceneChange.detector import SceneChangeMSECuda
+
+            return SceneChangeMSECuda(threshold, self.half)
+
+        case "maxxvit-tensorrt" | "maxxvit-directml":
+            from src.sceneChange.detector import SceneChangeScorer6chDetector
+
+            return SceneChangeScorer6chDetector(method, threshold, self.half, size=224)
+
+        case _:
+            raise ValueError(f"Unknown scenechange_method: {method}")

--- a/src/gmfss/gmfss.py
+++ b/src/gmfss/gmfss.py
@@ -133,6 +133,17 @@ class GMFSS:
         self.I0.copy_(self.I1, non_blocking=self.use_cuda_stream)
 
     @torch.inference_mode()
+    def cacheFrameReset(self, frame):
+        # Scene-cut reset: anchor I0 = frame. GMFSS's only cross-frame state is
+        # I0 (the per-pair `reuse` cache in __call__ is a local, recomputed every
+        # call), so staging the new frame into I0 is a complete reset. firstRun
+        # stays False.
+        with self.stream_context():
+            self.stageFrame(frame, self.I0)
+        if self.stream is not None:
+            self.stream.synchronize()
+
+    @torch.inference_mode()
     def processFrame(self, frame):
         self.validateFrame(frame)
         return frame.to(

--- a/src/initializeModels.py
+++ b/src/initializeModels.py
@@ -13,6 +13,7 @@ def initializeModels(self):
     interpolateProcess = None
     restoreProcess = None
     dedupProcess = None
+    sceneChangeProcess = None
 
     if self.upscale:
         if ADOBE:
@@ -58,6 +59,18 @@ def initializeModels(self):
 
         dedupProcess = buildDedupProcess(self)
 
+    if self.interpolate and getattr(self, "sceneChange", False):
+        if ADOBE:
+            progressState.update(
+                {
+                    "status": f"Initializing scene-cut detector: {self.sceneChangeMethod}..."
+                }
+            )
+
+        from src.factories.sceneChange import buildSceneChangeProcess
+
+        sceneChangeProcess = buildSceneChangeProcess(self)
+
     return (
         outputWidth,
         outputHeight,
@@ -65,4 +78,5 @@ def initializeModels(self):
         interpolateProcess,
         restoreProcess,
         dedupProcess,
+        sceneChangeProcess,
     )

--- a/src/interpolate/distildrba.py
+++ b/src/interpolate/distildrba.py
@@ -269,15 +269,17 @@ class DistilDRBACuda:
     @torch.inference_mode()
     def cacheFrameReset(self, frame: torch.Tensor):
         """
-        Reset feature cache on scene change.
-        Called when scene detection triggers a scene change.
+        Scene-cut reset: anchor I0 = frame and clear the 3-frame feature cache
+        so the next interpolation starts fresh in the new scene. firstRun stays
+        False: the loop already emitted the held frames, and the next __call__
+        must interpolate I0(=this frame) <-> next frame (a firstRun path would
+        instead swallow that frame's interpolation).
         """
         self.f0 = None
         self.f1 = None
         self.f2 = None
-        # Reset frame buffers - start fresh with this frame as I0
         self.I0 = self.prepareFrame(frame)
-        self.firstRun = True
+        self.firstRun = False
 
     @torch.inference_mode()
     def __call__(
@@ -654,10 +656,12 @@ class DistilDRBATensorRT:
 
     @torch.inference_mode()
     def cacheFrameReset(self, frame: torch.Tensor):
-        """Reset cache on scene change."""
+        """Scene-cut reset: anchor I0 = frame (I0 python state + tImg0 binding).
+        firstRun stays False so the next __call__ interpolates this frame <->
+        the next frame instead of swallowing it (see DistilDRBACuda)."""
         self.I0 = frame.to(dtype=self.dtype, device=self.device, non_blocking=True)
         self.processFrame(frame, "img0")
-        self.firstRun = True
+        self.firstRun = False
 
     @torch.inference_mode()
     def __call__(

--- a/src/interpolate/rife.py
+++ b/src/interpolate/rife.py
@@ -401,8 +401,40 @@ class RifeCuda:
 
     @torch.inference_mode()
     def cacheFrameReset(self, frame):
-        self.processFrame(frame, "cache")
-        self.processFrame(self.I0, "model")
+        """
+        Scene-cut reset: make ``frame`` the sole anchor (I0) and re-seed the
+        encoder feature ``f0 = encode(frame)``, so the next call interpolates
+        ``frame`` <-> next-frame with no bleed from the previous scene. Leaves
+        ``firstRun`` False (we already have an anchor) — the next ``__call__``
+        takes the normal I1/interpolate path.
+
+        GRAPH-SAFE: the forward is captured in a CUDA graph that reads ``I0`` and
+        ``self.model.f0`` at FIXED addresses. Both are updated IN-PLACE via
+        ``copy_`` — never reassigned. The arch's own ``cacheReset`` does
+        ``self.f0 = self.encode(...)`` (a reassignment), which would leave graph
+        replay reading the stale captured tensor; that is why we do not call it
+        here when the graph is active.
+        """
+        with torch.cuda.stream(self.normStream):
+            padded = self.padFrame(
+                frame.to(device=checker.device, dtype=self.dType, non_blocking=True)
+            )
+            self.I0.copy_(padded, non_blocking=True)
+            if getattr(self.model, "encode", None) is not None:
+                if getattr(self.model, "f0", None) is not None:
+                    # In-place re-seed of the persistent (graph-captured) f0.
+                    self.model.f0.copy_(
+                        self.model.encode(padded[:, :3]), non_blocking=True
+                    )
+                else:
+                    # No forward has run yet (eager path, graph disabled): the
+                    # next forward lazily encodes img0=I0, so leaving f0 None is
+                    # correct.
+                    self.model.f0 = None
+            # Re-arm the arch's ensemble/factor counter to its initial state.
+            if hasattr(self.model, "counter"):
+                self.model.counter = 1
+        self.normStream.synchronize()
 
     @torch.inference_mode()
     def processFrame(self, frame, toNorm):
@@ -653,7 +685,10 @@ class RifeMPS:
 
     @torch.inference_mode()
     def cacheFrameReset(self, frame):
-        self.processFrame(frame, "cache")
+        # Scene-cut reset: anchor I0 = frame and re-seed the encoder feature
+        # f0 = encode(frame). MPS runs eager (no CUDA graph), so the arch's
+        # cacheReset reassigning f0 is fine. firstRun stays False.
+        self.processFrame(frame, "I0")
         self.processFrame(self.I0, "model")
 
     @torch.inference_mode()

--- a/src/interpolate/rife_ncnn.py
+++ b/src/interpolate/rife_ncnn.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 
 from src.infra.isCudaInit import CudaChecker
@@ -242,13 +241,10 @@ class RifeNCNN:
         self._frame0Idx = 1 - self._frame0Idx
 
     def cacheFrameReset(self, frame):
-        arr = (
-            frame.cpu().numpy().astype("uint8")
-            if torch.is_tensor(frame)
-            else np.asarray(frame).astype("uint8")
-        )
-        arr = np.ascontiguousarray(arr).reshape(self.height, self.width, 3)
-        self._frameBytes[self._frame0Idx][:] = arr.tobytes()
+        # Scene-cut reset: make `frame` the anchor (frame0 slot). Reuse the
+        # normal 0..1-float -> HWC-uint8 conversion (_writeFrameInto); NCNN is
+        # stateless per pair, so there is no feature cache to clear.
+        self._writeFrameInto(frame, self._frame0Idx)
         self._firstFrame = False
 
     def __call__(self, frame, interpQueue, framesToInsert=1, timesteps=None):

--- a/src/interpolate/rife_tensorrt.py
+++ b/src/interpolate/rife_tensorrt.py
@@ -529,7 +529,15 @@ class RifeTensorRT:
 
     @torch.inference_mode()
     def cacheFrameReset(self, frame):
+        # Scene-cut reset: re-anchor I0 = frame and, for Head models, re-seed the
+        # encoder embedding f0 = encode(frame) IN-PLACE. The engine reads f0 as a
+        # fixed binding and otherwise carries it across frames via the "f0-copy"
+        # step, so without re-seeding here the previous scene's embedding bleeds
+        # into the first interpolation after the cut. Both "I0" and "f0"
+        # processFrame cases copy into the fixed buffers (graph/binding-safe).
         self.processFrame(frame, "I0")
+        if self.norm is not None:
+            self.processFrame(frame, "f0")
 
     @torch.inference_mode()
     def __call__(self, frame, interpQueue, framesToInsert=1, timesteps=None):

--- a/src/sceneChange/__init__.py
+++ b/src/sceneChange/__init__.py
@@ -1,0 +1,12 @@
+"""
+Streaming, per-frame-pair scene-change detection for the interpolation path.
+
+Unlike ``src/autoclip`` (a whole-video prepass that writes cut timestamps to a
+txt file), these detectors score a single ``(prev, curr)`` pair inside the main
+frame loop and return a bool: True == hard cut. On a cut the interpolation loop
+emits duplicated source frames instead of morphing across the cut, and resets
+the interp driver's frame/feature cache via ``cacheFrameReset``.
+
+Cheap tier (ssim/mse) reuses ``src/dedup``; the maxxvit tier reuses the 6-channel
+classifier scorer shared with ``src/autoclip/autoclipMaxxvit.py``.
+"""

--- a/src/sceneChange/detector.py
+++ b/src/sceneChange/detector.py
@@ -18,10 +18,6 @@ cut-probability exceeds the threshold.
 import torch
 import torch.nn.functional as F
 
-from src.infra.isCudaInit import CudaChecker
-
-checker = CudaChecker()
-
 
 class _SSIMBase:
     """Shared SSIM cut logic; subclasses set device/dtype and resize mode."""

--- a/src/sceneChange/detector.py
+++ b/src/sceneChange/detector.py
@@ -1,0 +1,157 @@
+"""
+Streaming scene-change detectors.
+
+Each detector is a callable ``__call__(frame) -> bool`` returning True when
+``frame`` is a hard cut relative to the previously seen frame. The detector
+holds its own downsampled reference frame and advances it EVERY call (unlike
+dedup, which only advances on a kept frame). The first frame always returns
+False (no predecessor).
+
+Cheap tier (ssim/mse) reuses the SSIM module and MSE math from ``src/dedup``.
+A cut is the inverse of the dedup duplicate test:
+  - SSIM: high == similar, so cut when ``ssim < threshold``.
+  - MSE:  low  == similar, so cut when ``mse > threshold``.
+The maxxvit tier reuses the shared 6-channel classifier; cut when the softmax
+cut-probability exceeds the threshold.
+"""
+
+import torch
+import torch.nn.functional as F
+
+from src.infra.isCudaInit import CudaChecker
+
+checker = CudaChecker()
+
+
+class _SSIMBase:
+    """Shared SSIM cut logic; subclasses set device/dtype and resize mode."""
+
+    def __init__(self, threshold, sampleSize, device, half, mode):
+        from src.dedup.ssim import SSIM
+
+        self.threshold = threshold
+        self.sampleSize = sampleSize
+        self.device = device
+        self.half = half
+        self.mode = mode
+        self.prevFrame = None
+        self.ssim = SSIM(data_range=1.0, channel=3).to(device)
+        if half:
+            self.ssim.half()
+        else:
+            self.ssim.float()
+        self.ssim.eval()
+
+    def _prep(self, frame):
+        frame = frame.half() if self.half else frame.float()
+        return F.interpolate(
+            frame, (self.sampleSize, self.sampleSize), mode=self.mode
+        ).to(self.device)
+
+    @torch.inference_mode()
+    def __call__(self, frame):
+        cur = self._prep(frame)
+        if self.prevFrame is None:
+            self.prevFrame = cur
+            return False
+        score = self.ssim(self.prevFrame, cur).mean().item()
+        self.prevFrame = cur
+        # SSIM high == similar; a scene cut is a large drop in similarity.
+        return score < self.threshold
+
+
+class SceneChangeSSIMCuda(_SSIMBase):
+    def __init__(self, threshold=0.5, half=True, sampleSize=224):
+        super().__init__(
+            threshold,
+            sampleSize,
+            device=torch.device("cuda"),
+            half=half,
+            mode="nearest",
+        )
+
+
+class SceneChangeSSIM(_SSIMBase):
+    def __init__(self, threshold=0.5, sampleSize=224):
+        # CPU SSIM: bilinear resize (matches DedupSSIM), fp32.
+        super().__init__(
+            threshold,
+            sampleSize,
+            device=torch.device("cpu"),
+            half=False,
+            mode="bilinear",
+        )
+
+    def _prep(self, frame):
+        return F.interpolate(
+            frame.float(),
+            size=(self.sampleSize, self.sampleSize),
+            mode="bilinear",
+            align_corners=False,
+        ).to(self.device)
+
+
+class _MSEBase:
+    """Shared MSE cut logic. MSE low == similar, so cut when mse > threshold."""
+
+    def __init__(self, threshold, sampleSize, half, cuda):
+        self.threshold = threshold
+        self.sampleSize = sampleSize
+        self.half = half
+        self.cuda = cuda
+        self.prevFrame = None
+
+    def _prep(self, frame):
+        if self.cuda:
+            frame = frame.half() if self.half else frame.float()
+            return F.interpolate(
+                frame, (self.sampleSize, self.sampleSize), mode="nearest"
+            ).mul(255.0)
+        return F.interpolate(
+            frame.float(),
+            size=(self.sampleSize, self.sampleSize),
+            mode="bilinear",
+            align_corners=False,
+        ).mul(255.0)
+
+    @torch.inference_mode()
+    def __call__(self, frame):
+        cur = self._prep(frame)
+        if self.prevFrame is None:
+            self.prevFrame = cur
+            return False
+        score = ((self.prevFrame - cur) ** 2).mean().item()
+        self.prevFrame = cur
+        return score > self.threshold
+
+
+class SceneChangeMSECuda(_MSEBase):
+    def __init__(self, threshold=1000.0, half=True, sampleSize=224):
+        super().__init__(threshold, sampleSize, half=half, cuda=True)
+
+
+class SceneChangeMSE(_MSEBase):
+    def __init__(self, threshold=1000.0, sampleSize=224):
+        super().__init__(threshold, sampleSize, half=False, cuda=False)
+
+
+class SceneChangeScorer6chDetector:
+    """Wrap the shared 6-channel ONNX classifier (maxxvit / differential /
+    shift_lpips) as a streaming detector. Cut when cut-probability >
+    threshold."""
+
+    def __init__(self, method, threshold=0.5, half=True, size=224):
+        from src.sceneChange.scorer6ch import SceneChangeScorer6ch
+
+        self.threshold = threshold
+        self.scorer = SceneChangeScorer6ch(method, half, size=size)
+        self.prevFrame = None
+
+    def __call__(self, frame):
+        cur = self.scorer.preprocessCHW(frame)
+        if self.prevFrame is None:
+            self.prevFrame = cur
+            return False
+        prob = self.scorer.score(self.prevFrame, cur)
+        self.prevFrame = cur
+        return prob > self.threshold

--- a/src/sceneChange/scorer6ch.py
+++ b/src/sceneChange/scorer6ch.py
@@ -1,0 +1,218 @@
+"""
+Shared 6-channel scene-change scorer.
+
+Scores a ``(prev, curr)`` RGB frame pair with an ONNX classifier that takes the
+two frames concatenated along the channel axis (6-channel input, HxW resize) and
+returns a scalar cut probability (softmax ``[0][0]``).
+
+This is the pure scoring core lifted out of ``AutoClipMaxxvit`` so that BOTH the
+whole-video autoclip prepass and the streaming interpolation-path detector share
+one implementation. The prepass feeds already-decoded HWC uint8 frames
+(``preprocessHWC``); the streaming detector feeds ``(1, 3, H, W)`` float [0,1]
+tensors (``preprocessCHW``). ``score`` is identical for both.
+"""
+
+import logging
+import os
+
+import numpy as np
+import torch
+
+from src.infra.logAndPrint import logAndPrint
+from src.model.download import downloadModels
+from src.model.registry import modelsMap, weightsDir
+
+
+class SceneChangeScorer6ch:
+    """
+    6-channel (prev+curr) ONNX scene-change classifier.
+
+    Args:
+        method: e.g. ``"maxxvit-tensorrt"`` or ``"maxxvit-directml"``. The
+            ``-tensorrt`` / ``-directml`` suffix selects the backend.
+        half: request fp16 (ignored for the TensorRT path — the model's softmax
+            saturates in fp16 and TRT 10.x lacks an fp16 depthwise-conv kernel at
+            this shape, so TRT is pinned to fp32; mirrors AutoClipMaxxvit).
+        size: model spatial input (square). maxxvit == 224.
+    """
+
+    def __init__(self, method: str, half: bool, size: int = 224):
+        self.method = method
+        self.half = half
+        self.H = self.W = size
+        self.backend = "tensorrt" if method.endswith("-tensorrt") else "directml"
+        self._loadModel()
+
+    # ---- model loading (lifted from AutoClipMaxxvit) -----------------------
+
+    def _resolveModelPath(self):
+        # TensorRT path is pinned to fp32 weights + fp32 engine because TRT 10.x
+        # lacks an fp16 kernel for the depthwise conv at this shape, and the
+        # model's softmax is numerically unstable in fp16 (saturates).
+        weightHalf = False if self.backend == "tensorrt" else self.half
+        filename = modelsMap(self.method, half=weightHalf, modelType="onnx")
+        folderName = self.method.replace("-tensorrt", "-onnx").replace(
+            "-directml", "-onnx"
+        )
+        modelPath = os.path.join(weightsDir, folderName, filename)
+        if not os.path.exists(modelPath):
+            modelPath = downloadModels(
+                model=self.method, half=weightHalf, modelType="onnx"
+            )
+        return modelPath
+
+    def _loadModel(self):
+        self.modelPath = self._resolveModelPath()
+        if self.backend == "tensorrt":
+            self._loadTensorRT()
+        else:
+            self._loadDirectML()
+
+    def _loadDirectML(self):
+        import onnxruntime as ort
+
+        providers = ort.get_available_providers()
+        if "DmlExecutionProvider" in providers:
+            logging.info("Using DirectML for scene-change 6ch inference")
+            self.session = ort.InferenceSession(
+                self.modelPath, providers=["DmlExecutionProvider"]
+            )
+        else:
+            logAndPrint(
+                "DirectML provider not available, falling back to CPU. "
+                "Performance will be significantly worse.",
+                "yellow",
+            )
+            self.session = ort.InferenceSession(
+                self.modelPath, providers=["CPUExecutionProvider"]
+            )
+
+    def _loadTensorRT(self):
+        from src.model.trtHandler import (
+            tensorRTEngineCreator,
+            tensorRTEngineLoader,
+            tensorRTEngineNameHandler,
+        )
+        from src.utils.tensorrt_import import trt
+
+        self.trt = trt
+
+        if self.half:
+            logging.warning(
+                "scene-change 6ch tensorrt ignores --half: model softmax "
+                "overflows in fp16. Building/using fp32 engine."
+            )
+        useFp16 = False
+
+        enginePath = tensorRTEngineNameHandler(
+            modelPath=self.modelPath,
+            fp16=useFp16,
+            optInputShape=[0, 6, self.H, self.W],
+        )
+
+        engine, context = tensorRTEngineLoader(enginePath)
+        if engine is None or context is None or not os.path.exists(enginePath):
+            engine, context = tensorRTEngineCreator(
+                modelPath=self.modelPath,
+                enginePath=enginePath,
+                fp16=useFp16,
+                inputsMin=[6, self.H, self.W],
+                inputsOpt=[6, self.H, self.W],
+                inputsMax=[6, self.H, self.W],
+            )
+
+        if engine is None or context is None:
+            raise RuntimeError(
+                f"Failed to build/load TensorRT engine for {self.modelPath}"
+            )
+
+        self.engine = engine
+        self.context = context
+
+        self.dType = torch.float32
+        self.device = torch.device("cuda")
+        self.stream = torch.cuda.Stream()
+
+        self.dummyInput = torch.zeros(
+            (6, self.H, self.W), device=self.device, dtype=self.dType
+        )
+        self.dummyOutput = torch.zeros((1, 2), device=self.device, dtype=self.dType)
+
+        bindings = [self.dummyInput.data_ptr(), self.dummyOutput.data_ptr()]
+        for i in range(self.engine.num_io_tensors):
+            tensorName = self.engine.get_tensor_name(i)
+            self.context.set_tensor_address(tensorName, bindings[i])
+            if self.engine.get_tensor_mode(tensorName) == trt.TensorIOMode.INPUT:
+                self.context.set_input_shape(tensorName, self.dummyInput.shape)
+
+        with torch.cuda.stream(self.stream):
+            for _ in range(5):
+                self.context.execute_async_v3(stream_handle=self.stream.cuda_stream)
+            self.stream.synchronize()
+
+        self.cudaGraph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self.cudaGraph, stream=self.stream):
+            self.context.execute_async_v3(stream_handle=self.stream.cuda_stream)
+        self.stream.synchronize()
+
+    # ---- preprocessing -----------------------------------------------------
+
+    def preprocessHWC(self, hwcTensor):
+        """Prepass path: nelux HWC uint8 -> CHW [0,1] (numpy for DML, torch GPU
+        for TRT)."""
+        if self.backend == "tensorrt":
+            with torch.cuda.stream(self.stream):
+                t = (
+                    hwcTensor.to(device=self.device, non_blocking=True)
+                    .to(self.dType)
+                    .div_(255.0)
+                    .permute(2, 0, 1)
+                )
+            return t
+        arr = hwcTensor.numpy()
+        arr = arr.astype(np.float16 if self.half else np.float32) / 255.0
+        return np.ascontiguousarray(arr.transpose(2, 0, 1))
+
+    def preprocessCHW(self, frame):
+        """Streaming path: a ``(1, 3, H, W)`` (or ``(3, H, W)``) float [0,1]
+        tensor -> CHW [0,1] resized to the model input, matching the backend's
+        tensor type."""
+        import torch.nn.functional as F
+
+        if frame.dim() == 3:
+            frame = frame.unsqueeze(0)
+        resized = F.interpolate(
+            frame.float(),
+            size=(self.H, self.W),
+            mode="bilinear",
+            align_corners=False,
+        ).squeeze(0)  # (3, H, W) in [0,1]
+        if self.backend == "tensorrt":
+            return resized.to(device=self.device, dtype=self.dType)
+        return np.ascontiguousarray(
+            resized.detach()
+            .cpu()
+            .numpy()
+            .astype(np.float16 if self.half else np.float32)
+        )
+
+    # ---- scoring (lifted from AutoClipMaxxvit) -----------------------------
+
+    def scoreDirectML(self, prev, curr):
+        inputs = np.concatenate((prev, curr), axis=0)
+        result = self.session.run(None, {"input": inputs})[0]
+        return float(result[0][0])
+
+    def scoreTensorRT(self, prev, curr):
+        with torch.cuda.stream(self.stream):
+            self.dummyInput.copy_(torch.cat((prev, curr), dim=0), non_blocking=True)
+            self.cudaGraph.replay()
+            score = self.dummyOutput[0][0].item()
+        self.stream.synchronize()
+        return score
+
+    def score(self, prev, curr):
+        """Cut probability for a preprocessed pair (softmax ``[0][0]``)."""
+        if self.backend == "tensorrt":
+            return self.scoreTensorRT(prev, curr)
+        return self.scoreDirectML(prev, curr)

--- a/tests/test_registryDrift.py
+++ b/tests/test_registryDrift.py
@@ -145,6 +145,14 @@ KNOWN_UNREGISTERED_METHODS = {
         "distildrba-tensorrt",  # weights ship via the base distildrba entry
         "distildrba-lite-tensorrt",  # weights ship via the base distildrba-lite entry
     },
+    "scenechange": {
+        # streaming scene-cut detectors; the cheap tier is algorithmic (no
+        # weights). maxxvit-* ride the registered maxxvit ONNX entries.
+        "ssim",
+        "mse",
+        "ssim-cuda",
+        "mse-cuda",
+    },
     "restore": {
         # registered under their -mps/-tensorrt siblings or external SDKs
         "fastlinedarken",

--- a/tests/test_sceneChange.py
+++ b/tests/test_sceneChange.py
@@ -116,3 +116,55 @@ def testFactoryMapsMethods():
     fake.sceneChangeMethod = "bogus"
     with pytest.raises(ValueError):
         buildSceneChangeProcess(fake)
+
+
+def _scArgs(method):
+    import argparse
+
+    return argparse.Namespace(
+        slowmo=False,
+        static_step=False,
+        interpolate_factor=2,
+        dedup=False,
+        autoclip=False,
+        compile_mode="default",
+        interpolate=True,
+        scenechange=True,
+        scenechange_method=method,
+        scenechange_sens=50.0,
+    )
+
+
+def testValidatorDowngradesCudaMethodsWithoutCuda(monkeypatch):
+    # On a box without CUDA, the default ssim-cuda (and other CUDA/TRT
+    # detectors) would crash at device init; the validator must downgrade them.
+    import src.infra.isCudaInit as ic
+    from src.cli.validator import _configureProcessingSettings
+
+    class FakeChecker:
+        cudaAvailable = False
+
+    monkeypatch.setattr(ic, "CudaChecker", FakeChecker)
+
+    for src_m, dst_m in (
+        ("ssim-cuda", "ssim"),
+        ("mse-cuda", "mse"),
+        ("maxxvit-tensorrt", "maxxvit-directml"),
+    ):
+        a = _scArgs(src_m)
+        _configureProcessingSettings(a)
+        assert a.scenechange_method == dst_m, f"{src_m} should downgrade to {dst_m}"
+        assert a.scenechange_threshold is not None
+
+
+def testValidatorKeepsCudaMethodsWithCuda(monkeypatch):
+    import src.infra.isCudaInit as ic
+    from src.cli.validator import _configureProcessingSettings
+
+    class FakeChecker:
+        cudaAvailable = True
+
+    monkeypatch.setattr(ic, "CudaChecker", FakeChecker)
+    a = _scArgs("ssim-cuda")
+    _configureProcessingSettings(a)
+    assert a.scenechange_method == "ssim-cuda"  # unchanged when CUDA present

--- a/tests/test_sceneChange.py
+++ b/tests/test_sceneChange.py
@@ -1,0 +1,118 @@
+"""Tests for src/sceneChange streaming scene-cut detectors.
+
+These gate the interpolation cut-skip: a detector returns True on a hard cut
+(so the loop holds instead of morphing across it). Semantics differ from dedup:
+  * dedup detects DUPLICATES (SSIM high / MSE low) and only advances its
+    reference on a kept frame.
+  * a scene detector detects CUTS (SSIM low / MSE high) and advances its
+    reference EVERY frame (each frame becomes the reference for the next).
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.sceneChange.detector import (
+    SceneChangeMSE,
+    SceneChangeMSECuda,
+    SceneChangeSSIM,
+)
+
+
+def _frame(value, h=64, w=64):
+    # NCHW float frame in [0, 1], matching the pipeline's tensor layout.
+    return torch.full((1, 3, h, w), float(value), dtype=torch.float32)
+
+
+def _noisyFrame(seed, h=64, w=64):
+    g = torch.Generator().manual_seed(seed)
+    return torch.rand((1, 3, h, w), generator=g, dtype=torch.float32)
+
+
+# --------------------------------------------------------------------------- #
+# SSIM cut detection (high == similar; cut when ssim < threshold)
+# --------------------------------------------------------------------------- #
+
+
+def testSSIMFirstFrameNeverCut():
+    d = SceneChangeSSIM(threshold=0.5)
+    assert d(_noisyFrame(0)) is False  # no predecessor
+
+
+def testSSIMIdenticalIsNotCut():
+    d = SceneChangeSSIM(threshold=0.5)
+    f = _noisyFrame(0)
+    assert d(f) is False
+    assert d(f.clone()) is False  # SSIM 1.0 -> similar -> no cut
+
+
+def testSSIMDisjointIsCut():
+    d = SceneChangeSSIM(threshold=0.5)
+    assert d(_noisyFrame(0)) is False
+    assert d(_noisyFrame(1)) is True  # uncorrelated -> SSIM ~0 -> cut
+
+
+def testSSIMReferenceAdvancesEveryFrame():
+    # After a cut A->B, B is the new reference: a repeat of B is NOT a cut.
+    d = SceneChangeSSIM(threshold=0.5)
+    a, b = _noisyFrame(0), _noisyFrame(1)
+    assert d(a) is False
+    assert d(b) is True  # cut A->B
+    assert d(b.clone()) is False  # B->B: reference advanced, no cut
+
+
+# --------------------------------------------------------------------------- #
+# MSE cut detection (low == similar; cut when mse > threshold). Direction is
+# OPPOSITE to SSIM -- pinned so the inversion can't sneak in.
+# --------------------------------------------------------------------------- #
+
+
+def testMSEIdenticalIsNotCut():
+    d = SceneChangeMSE(threshold=1000.0)
+    assert d(_frame(0.5)) is False  # first
+    assert d(_frame(0.5)) is False  # identical -> MSE 0 -> no cut
+
+
+def testMSEDisjointIsCut():
+    d = SceneChangeMSE(threshold=1000.0)
+    assert d(_frame(0.0)) is False  # first (black)
+    assert d(_frame(1.0)) is True  # black->white -> MSE 255^2 -> cut
+
+
+def testMSECudaLogicOnCpu():
+    # half=False allocates no CUDA tensors, so the logic runs on CPU frames.
+    d = SceneChangeMSECuda(threshold=1000.0, half=False)
+    assert d(_frame(0.0)) is False
+    assert d(_frame(1.0)) is True
+    assert d(_frame(1.0)) is False  # reference advanced to white -> no cut
+
+
+def testCudaDetectorsExist():
+    # The CUDA / ONNX detector classes must exist (they are advertised CLI
+    # choices routed by the factory) even though constructing them needs a GPU
+    # or model weights.
+    import src.sceneChange.detector as m
+
+    for name in ("SceneChangeSSIMCuda", "SceneChangeScorer6chDetector"):
+        assert isinstance(getattr(m, name), type)
+
+
+def testFactoryMapsMethods():
+    import types
+
+    from src.factories.sceneChange import buildSceneChangeProcess
+
+    fake = types.SimpleNamespace(
+        sceneChangeMethod="ssim",
+        sceneChangeThreshold=0.5,
+        half=False,
+    )
+    det = buildSceneChangeProcess(fake)
+    assert type(det).__name__ == "SceneChangeSSIM"
+
+    fake.sceneChangeMethod = "mse"
+    assert type(buildSceneChangeProcess(fake)).__name__ == "SceneChangeMSE"
+
+    fake.sceneChangeMethod = "bogus"
+    with pytest.raises(ValueError):
+        buildSceneChangeProcess(fake)


### PR DESCRIPTION
## Scene-cut-aware interpolation (`--scenechange`)

Opt-in. On a hard scene cut, **hold** the frame instead of letting RIFE morph across it (removes the melt/ghost frame at cut boundaries). Inspired by HolyWu's vs-rife `sc`.

### Usage
- `--scenechange` — enable (requires `--interpolate`)
- `--scenechange_method` — `ssim` | `ssim-cuda` | `mse` | `mse-cuda` | `maxxvit-tensorrt` | `maxxvit-directml` (default `ssim-cuda`)
- `--scenechange_sens` — 0-100 (default 50), mapped to a per-method threshold

### How
- Streaming per-frame-pair detector in `main.py:processFrame`. Cheap ssim/mse reuse `src/dedup`; maxxvit reuses a new shared 6ch scorer (`src/sceneChange/scorer6ch.py`) also consumed by the autoclip prepass (DRY).
- On a cut: emit held frames + `cacheFrameReset`. The reset contract is unified across **all** interp backends — RifeCuda/TensorRT re-seed `I0`/`f0` in-place (graph/binding-safe); MPS/NCNN/DirectML/GMFSS/DistilDRBA covered. Fixes a latent `RifeNCNN` reset bug (skipped ×255 + mis-shape) and stops DistilDRBA dropping one interpolation after a cut.
- `transnetv2`/`pyscenedetect` remain prepass-only (`--autoclip`).

### Verification
- **Frame-count parity** sc-off vs sc-on across 7 combos (interp, ±upscale first/last, ±dedup incl. drops, ×3, float ×2.5) — no dropped/duplicated/missized frames; upscale output correctly 2×.
- Reset correctness verified on-box (CUDA/TensorRT/DirectML/GMFSS): `interp(B,B)≈B` after a cut, no scene bleed. MPS/NCNN/DistilDRBA logic-checked (no local weights/HW).
- 239 tests pass (10 new), ruff clean.

Docs updated: PARAMETERS.MD, CHANGELOG.MD, CLAUDE.md.