### PR TITLE
Optimize video hot path frame handling

### DIFF
--- a/benchmarks/perf/hotloop_microbench.py
+++ b/benchmarks/perf/hotloop_microbench.py
@@ -174,11 +174,15 @@ def bench_queue(args: argparse.Namespace) -> dict:
     else:
         device = "cpu"
     tensor = torch.empty((1, 3, args.height, args.width), device=device)
+    q = queue.Queue()
 
     def queue_step() -> None:
-        q = queue.Queue()
         q.put(tensor)
-        q.get_nowait()
+        while True:
+            try:
+                q.get_nowait()
+            except queue.Empty:
+                break
 
     collector = Collector()
 

--- a/benchmarks/perf/hotloop_microbench.py
+++ b/benchmarks/perf/hotloop_microbench.py
@@ -29,6 +29,17 @@ class Sink:
         self.count += 1
 
 
+class Collector:
+    def __init__(self) -> None:
+        self.frames = []
+
+    def put(self, item) -> None:
+        self.frames.append(item)
+
+    def clear(self) -> None:
+        self.frames.clear()
+
+
 @dataclass
 class TimedRun:
     iterations: int
@@ -40,6 +51,8 @@ class TimedRun:
 def _sync() -> None:
     if torch.cuda.is_available():
         torch.cuda.synchronize()
+    elif hasattr(torch, "mps") and torch.backends.mps.is_available():
+        torch.mps.synchronize()
 
 
 def _event_ms(fn, iterations: int) -> float:
@@ -154,12 +167,27 @@ def bench_rife(args: argparse.Namespace) -> dict:
 
 
 def bench_queue(args: argparse.Namespace) -> dict:
-    tensor = torch.empty((1, 3, args.height, args.width), device="cuda")
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        device = "mps"
+    else:
+        device = "cpu"
+    tensor = torch.empty((1, 3, args.height, args.width), device=device)
 
     def queue_step() -> None:
         q = queue.Queue()
         q.put(tensor)
         q.get_nowait()
+
+    collector = Collector()
+
+    def collector_step() -> None:
+        collector.clear()
+        collector.put(tensor)
+        for _item in collector.frames:
+            pass
+        collector.clear()
 
     sink = Sink()
 
@@ -167,10 +195,15 @@ def bench_queue(args: argparse.Namespace) -> dict:
         sink.put(tensor)
 
     queue_run = calibrate(queue_step, target_ms=args.target_ms, max_iterations=100_000)
+    collector_run = calibrate(
+        collector_step, target_ms=args.target_ms, max_iterations=100_000
+    )
     sink_run = calibrate(sink_step, target_ms=args.target_ms, max_iterations=100_000)
     return {
         "bench": "queue_overhead",
+        "device": device,
         "queue": queue_run.__dict__,
+        "collector": collector_run.__dict__,
         "sink": sink_run.__dict__,
     }
 

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ import sys
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from fractions import Fraction
-from queue import Empty, Queue
+from queue import Empty
 from time import time
 
 os.environ.setdefault("FOR_DISABLE_CONSOLE_CTRL_HANDLER", "1")
@@ -64,6 +64,21 @@ _disableUserSitePackages()
 import src.constants as cs  # noqa: E402
 
 warnings.filterwarnings("ignore")
+
+
+class _FrameCollector:
+    """Small same-thread sink for interpolation outputs."""
+
+    __slots__ = ("frames",)
+
+    def __init__(self) -> None:
+        self.frames = []
+
+    def put(self, frame) -> None:
+        self.frames.append(frame)
+
+    def clear(self) -> None:
+        self.frames.clear()
 
 
 def _setTerminalTitle(title: str) -> None:
@@ -365,12 +380,9 @@ class VideoProcessor:
             self.interpolate_process(frame, sink, self.framesToInsert, self.timesteps)
 
     def _drainInterpQueue(self) -> None:
-        while True:
-            try:
-                item = self.interpQueue.get_nowait()
-            except Empty:
-                break
+        for item in self.interpQueue.frames:
             self.writeBuffer.write(item)
+        self.interpQueue.clear()
 
     def ifInterpolateFirst(self, frame: any) -> None:
         """
@@ -380,16 +392,14 @@ class VideoProcessor:
             frame: Input video frame tensor
         """
         if self.interpolate:
+            self.interpQueue.clear()
             self._interpolateOrHold(frame, self.interpQueue)
 
         if self.upscale:
             if self.interpolate:
-                while True:
-                    try:
-                        item = self.interpQueue.get_nowait()
-                    except Empty:
-                        break
+                for item in self.interpQueue.frames:
                     self.writeBuffer.write(self.upscale_process(item, self.nextFrame))
+                self.interpQueue.clear()
 
                 self.writeBuffer.write(self.upscale_process(frame, self.nextFrame))
 
@@ -445,7 +455,7 @@ class VideoProcessor:
         self.framesToInsert = self.interpolateFactor - 1 if self.interpolate else 0
 
         if self.interpolate and self.interpolateFirst:
-            self.interpQueue = Queue(maxsize=round(self.interpolateFactor))
+            self.interpQueue = _FrameCollector()
 
         try:
             currentFrame = self.readBuffer.read()

--- a/src/interpolate/rife_tensorrt.py
+++ b/src/interpolate/rife_tensorrt.py
@@ -440,6 +440,7 @@ class RifeTensorRT:
             dtype=self.dtype,
             device=checker.device,
         )
+        self._cachedTimestepValue = 0.5
 
         self.dummyOutput = torch.zeros(
             (1, 3, self.height, self.width),
@@ -557,10 +558,10 @@ class RifeTensorRT:
             else:
                 t = (i + 1) * 1 / (framesToInsert + 1)
 
-            self.dummyTimeStep.fill_(t)
-
-            self.processFrame(self.dummyTimeStep, "timestep")
             with torch.cuda.stream(self.stream):
+                if self._cachedTimestepValue != t:
+                    self.dummyTimeStep.fill_(t)
+                    self._cachedTimestepValue = t
                 self.cudaGraph.replay()
             self.stream.synchronize()
             with torch.cuda.stream(self.outputStream):

--- a/src/io/ffmpegSettings.py
+++ b/src/io/ffmpegSettings.py
@@ -1135,6 +1135,7 @@ class NeluxWriteBuffer:
         fps: float = 60.0,
         inpoint: float = 0.0,
         outpoint: float = 0.0,
+        benchmark: bool = False,
         **kwargs,  # Accept and ignore other WriteBuffer params for compatibility
     ):
         """
@@ -1158,6 +1159,7 @@ class NeluxWriteBuffer:
         self.fps = fps
         self.inpoint = inpoint
         self.outpoint = outpoint
+        self.benchmark = benchmark
         self.writeBuffer = Queue(maxsize=32)
         self.writtenFrames = 0
         self.CudaStream = None
@@ -1271,6 +1273,15 @@ class NeluxWriteBuffer:
         import torch
 
         try:
+            if self.benchmark:
+                while True:
+                    frame = self.writeBuffer.get()
+                    if frame is None:
+                        break
+                    self.writtenFrames += 1
+                logging.info(f"Nelux benchmark consumed {self.writtenFrames} frames")
+                return
+
             while self.writeBuffer.empty():
                 time.sleep(0.001)
 

--- a/src/io/ffmpegSettings.py
+++ b/src/io/ffmpegSettings.py
@@ -1161,6 +1161,7 @@ class NeluxWriteBuffer:
         self.writeBuffer = Queue(maxsize=32)
         self.writtenFrames = 0
         self.CudaStream = None
+        self.acceptsHwcUint8 = True
         # Nelux does not produce an FFmpeg-based preview image. Define the
         # attribute (matching WriteBuffer's None default) so main.py's preview
         # setup -- which reads writeBuffer.previewPath -- doesn't AttributeError
@@ -1310,6 +1311,18 @@ class NeluxWriteBuffer:
 
                 if frame is None:
                     break
+
+                if (
+                    isinstance(frame, torch.Tensor)
+                    and frame.ndim == 3
+                    and frame.dtype == torch.uint8
+                    and frame.shape[2] == 3
+                ):
+                    if not frame.is_contiguous():
+                        frame = frame.contiguous()
+                    self.encoder.encode_frame(frame)
+                    self.writtenFrames += 1
+                    continue
 
                 if self.CudaStream is not None:
                     with torch.cuda.stream(self.CudaStream):

--- a/src/motionBlur.py
+++ b/src/motionBlur.py
@@ -10,7 +10,7 @@ import torch
 
 from src.constants import ADOBE
 from src.infra.progressBarLogic import ProgressBarLogic
-from src.io.ffmpegSettings import BuildBuffer, WriteBuffer
+from src.io.ffmpegSettings import BuildBuffer, createWriteBuffer
 
 if ADOBE:
     from src.server.aeComms import progressState
@@ -346,14 +346,14 @@ class MotionBlurPipeline:
             decode_method=self.decodeMethod,
         )
 
-        self.writeBuffer = WriteBuffer(
-            self.input,
-            self.output,
-            self.encode_method,
-            self.custom_encoder,
-            self.width,
-            self.height,
-            self.fps,
+        self.writeBuffer = createWriteBuffer(
+            input=self.input,
+            output=self.output,
+            encode_method=self.encode_method,
+            custom_encoder=self.custom_encoder,
+            width=self.width,
+            height=self.height,
+            fps=self.fps,
             grayscale=False,
             benchmark=self.benchmark,
             bitDepth=self.bitDepth,

--- a/src/objectDetection/objectDetection.py
+++ b/src/objectDetection/objectDetection.py
@@ -10,7 +10,7 @@ from src.constants import ADOBE
 from src.infra.isCudaInit import CudaChecker
 from src.infra.logAndPrint import logAndPrint
 from src.infra.progressBarLogic import ProgressBarLogic
-from src.io.ffmpegSettings import BuildBuffer, WriteBuffer
+from src.io.ffmpegSettings import BuildBuffer, createWriteBuffer
 from src.model.download import downloadModels
 from src.model.registry import modelsMap, weightsDir
 
@@ -27,6 +27,56 @@ __all__ = [
     "ObjectDetectionTensorRT",
     "draw_detections",
 ]
+
+
+_INV_255 = 1.0 / 255.0
+
+
+def _writeRgbFrame(
+    writeBuffer, outputImg, writeHwcUint8: bool, copyHwc: bool = False
+) -> None:
+    if writeHwcUint8:
+        outputImg = (
+            np.array(outputImg, copy=True, order="C")
+            if copyHwc
+            else np.ascontiguousarray(outputImg)
+        )
+        writeBuffer.write(torch.from_numpy(outputImg))
+        return
+
+    outputTensor = (
+        torch.from_numpy(outputImg).permute(2, 0, 1).unsqueeze(0).to(torch.float32)
+    )
+    outputTensor.mul_(_INV_255)
+    writeBuffer.write(outputTensor)
+
+
+def _writeOutputFrame(writeBuffer, outputImgBgr, writeHwcUint8: bool) -> None:
+    _writeRgbFrame(
+        writeBuffer,
+        cv2.cvtColor(outputImgBgr, cv2.COLOR_BGR2RGB),
+        writeHwcUint8,
+    )
+
+
+def _rescaleBoxes(owner, boxes):
+    if boxes.size == 0:
+        return boxes.reshape(0, 4)
+    shape = (owner.imgWidth, owner.imgHeight)
+    if getattr(owner, "_boxScaleShape", None) != shape:
+        owner._boxScale = np.array(
+            [
+                owner.imgWidth / owner.inputWidth,
+                owner.imgHeight / owner.inputHeight,
+                owner.imgWidth / owner.inputWidth,
+                owner.imgHeight / owner.inputHeight,
+            ],
+            dtype=np.float32,
+        )
+        owner._boxScaleShape = shape
+    boxes = boxes.astype(np.float32, copy=False)
+    boxes *= owner._boxScale
+    return boxes
 
 
 class ObjectDetectionDML:
@@ -87,17 +137,18 @@ class ObjectDetectionDML:
                 toTorch=False,
             )
 
-            self.writeBuffer = WriteBuffer(
-                self.input,
-                self.output,
-                self.encodeMethod,
-                self.customEncoder,
-                self.width,
-                self.height,
-                self.fps,
+            self.writeBuffer = createWriteBuffer(
+                input=self.input,
+                output=self.output,
+                encode_method=self.encodeMethod,
+                custom_encoder=self.customEncoder,
+                width=self.width,
+                height=self.height,
+                fps=self.fps,
                 grayscale=False,
                 benchmark=self.benchmark,
             )
+            self.writeHwcUint8 = getattr(self.writeBuffer, "acceptsHwcUint8", False)
 
             with ThreadPoolExecutor(max_workers=3) as executor:
                 executor.submit(self.writeBuffer)
@@ -166,38 +217,30 @@ class ObjectDetectionDML:
         inputShape = modelInputs[0].shape
         self.inputHeight = inputShape[2] if isinstance(inputShape[2], int) else 640
         self.inputWidth = inputShape[3] if isinstance(inputShape[3], int) else 640
+        self._boxScale = None
+        self._boxScaleShape = None
 
     def prepareInput(self, image):
         self.imgHeight, self.imgWidth = image.shape[:2]
-        inputImg = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        inputImg = cv2.resize(inputImg, (self.inputWidth, self.inputHeight))
-        inputImg = inputImg / 255.0
-        inputImg = inputImg.transpose(2, 0, 1)
-        inputTensor = inputImg[np.newaxis, :, :, :].astype(np.float32)
+        inputImg = cv2.resize(image, (self.inputWidth, self.inputHeight))
+        inputTensor = inputImg.transpose(2, 0, 1)[np.newaxis, :, :, :].astype(
+            np.float32
+        )
+        inputTensor *= _INV_255
         return inputTensor
 
     def processOutput(self, output):
-        boxes = output[:, :-2]
         confidences = output[:, -2]
-        classIds = output[:, -1].astype(int)
-
         mask = confidences > self.confThreshold
-        boxes = boxes[mask, :]
+        boxes = output[mask, :-2]
         confidences = confidences[mask]
-        classIds = classIds[mask]
+        classIds = output[mask, -1].astype(int)
 
         boxes = self.rescaleBoxes(boxes)
         return classIds, boxes, confidences
 
     def rescaleBoxes(self, boxes):
-        inputShape = np.array(
-            [self.inputWidth, self.inputHeight, self.inputWidth, self.inputHeight]
-        )
-        boxes = np.divide(boxes, inputShape, dtype=np.float32)
-        boxes *= np.array(
-            [self.imgWidth, self.imgHeight, self.imgWidth, self.imgHeight]
-        )
-        return boxes
+        return _rescaleBoxes(self, boxes)
 
     def detect(self, image):
         inputTensor = self.prepareInput(image)
@@ -207,9 +250,14 @@ class ObjectDetectionDML:
     @torch.inference_mode()
     def processFrame(self, frame):
         try:
-            frameNp = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+            classIds, boxes, confidences = self.detect(frame)
+            if boxes.size == 0:
+                _writeRgbFrame(
+                    self.writeBuffer, frame, self.writeHwcUint8, copyHwc=True
+                )
+                return
 
-            classIds, boxes, confidences = self.detect(frameNp)
+            frameNp = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
 
             if self.disableAnnotations:
                 outputImg = frameNp.copy()
@@ -220,13 +268,7 @@ class ObjectDetectionDML:
             else:
                 outputImg = draw_detections(frameNp, boxes, confidences, classIds)
 
-            outputImg = cv2.cvtColor(outputImg, cv2.COLOR_BGR2RGB)
-            outputTensor = (
-                torch.from_numpy(outputImg).permute(2, 0, 1).unsqueeze(0).float()
-                / 255.0
-            )
-
-            self.writeBuffer.write(outputTensor)
+            _writeOutputFrame(self.writeBuffer, outputImg, self.writeHwcUint8)
 
         except Exception as e:
             logging.exception(f"Something went wrong while processing the frame, {e}")
@@ -307,17 +349,18 @@ class ObjectDetectionTensorRT:
                 toTorch=False,
             )
 
-            self.writeBuffer = WriteBuffer(
-                self.input,
-                self.output,
-                self.encodeMethod,
-                self.customEncoder,
-                self.width,
-                self.height,
-                self.fps,
+            self.writeBuffer = createWriteBuffer(
+                input=self.input,
+                output=self.output,
+                encode_method=self.encodeMethod,
+                custom_encoder=self.customEncoder,
+                width=self.width,
+                height=self.height,
+                fps=self.fps,
                 grayscale=False,
                 benchmark=self.benchmark,
             )
+            self.writeHwcUint8 = getattr(self.writeBuffer, "acceptsHwcUint8", False)
 
             with ThreadPoolExecutor(max_workers=3) as executor:
                 executor.submit(self.writeBuffer)
@@ -422,6 +465,8 @@ class ObjectDetectionTensorRT:
 
         self.inputName = inputName
         self.outputName = outputName
+        self._boxScale = None
+        self._boxScaleShape = None
 
         for i in range(self.engine.num_io_tensors):
             tensorName = self.engine.get_tensor_name(i)
@@ -442,11 +487,11 @@ class ObjectDetectionTensorRT:
     @torch.inference_mode()
     def prepareInput(self, image):
         self.imgHeight, self.imgWidth = image.shape[:2]
-        inputImg = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        inputImg = cv2.resize(inputImg, (self.inputWidth, self.inputHeight))
-        inputImg = inputImg / 255.0
-        inputImg = inputImg.transpose(2, 0, 1)
-        inputTensor = inputImg[np.newaxis, :, :, :].astype(np.float32)
+        inputImg = cv2.resize(image, (self.inputWidth, self.inputHeight))
+        inputTensor = inputImg.transpose(2, 0, 1)[np.newaxis, :, :, :].astype(
+            np.float32
+        )
+        inputTensor *= _INV_255
         return inputTensor
 
     @torch.inference_mode()
@@ -457,14 +502,11 @@ class ObjectDetectionTensorRT:
         if output.ndim == 3:
             output = output.squeeze(0)
 
-        boxes = output[:, :-2]
         confidences = output[:, -2]
-        classIds = output[:, -1].astype(int)
-
         mask = confidences > self.confThreshold
-        boxes = boxes[mask, :]
+        boxes = output[mask, :-2]
         confidences = confidences[mask]
-        classIds = classIds[mask]
+        classIds = output[mask, -1].astype(int)
         classIds = np.clip(classIds, 0, len(colors) - 1)
 
         boxes = self.rescaleBoxes(boxes)
@@ -479,14 +521,7 @@ class ObjectDetectionTensorRT:
 
     @torch.inference_mode()
     def rescaleBoxes(self, boxes):
-        inputShape = np.array(
-            [self.inputWidth, self.inputHeight, self.inputWidth, self.inputHeight]
-        )
-        boxes = np.divide(boxes, inputShape, dtype=np.float32)
-        boxes *= np.array(
-            [self.imgWidth, self.imgHeight, self.imgWidth, self.imgHeight]
-        )
-        return boxes
+        return _rescaleBoxes(self, boxes)
 
     @torch.inference_mode()
     def detect(self, image):
@@ -519,9 +554,14 @@ class ObjectDetectionTensorRT:
     @torch.inference_mode()
     def processFrame(self, frame):
         try:
-            frameNp = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+            classIds, boxes, confidences = self.detect(frame)
+            if boxes.size == 0:
+                _writeRgbFrame(
+                    self.writeBuffer, frame, self.writeHwcUint8, copyHwc=True
+                )
+                return
 
-            classIds, boxes, confidences = self.detect(frameNp)
+            frameNp = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
 
             if self.disableAnnotations:
                 outputImg = frameNp.copy()
@@ -532,13 +572,7 @@ class ObjectDetectionTensorRT:
             else:
                 outputImg = draw_detections(frameNp, boxes, confidences, classIds)
 
-            outputImg = cv2.cvtColor(outputImg, cv2.COLOR_BGR2RGB)
-            outputTensor = (
-                torch.from_numpy(outputImg).permute(2, 0, 1).unsqueeze(0).float()
-                / 255.0
-            )
-
-            self.writeBuffer.write(outputTensor)
+            _writeOutputFrame(self.writeBuffer, outputImg, self.writeHwcUint8)
 
         except Exception as e:
             logging.exception(f"Something went wrong while processing the frame, {e}")

--- a/src/stabilize/stabilize.py
+++ b/src/stabilize/stabilize.py
@@ -9,7 +9,7 @@ import torch
 import src.io.ffmpegSettings as ffmpegSettings
 from src.constants import ADOBE
 from src.infra.progressBarLogic import ProgressBarLogic
-from src.io.ffmpegSettings import BuildBuffer, WriteBuffer
+from src.io.ffmpegSettings import BuildBuffer, createWriteBuffer
 from src.stabilize.superpoint import SuperPoint, find_match_index, find_transform
 
 if ADOBE:
@@ -635,18 +635,19 @@ class VideoStabilize:
             toTorch=False,
         )
 
-        self.writeBuffer = WriteBuffer(
-            self.input,
-            self.output,
-            self.encode_method,
-            self.custom_encoder,
-            self.width,
-            self.height,
-            self.fps,
+        self.writeBuffer = createWriteBuffer(
+            input=self.input,
+            output=self.output,
+            encode_method=self.encode_method,
+            custom_encoder=self.custom_encoder,
+            width=self.width,
+            height=self.height,
+            fps=self.fps,
             grayscale=False,
             benchmark=self.benchmark,
             bitDepth=self.bitDepth,
         )
+        self.writeHwcUint8 = getattr(self.writeBuffer, "acceptsHwcUint8", False)
 
         with ThreadPoolExecutor(max_workers=3) as executor:
             writeFuture = executor.submit(self.writeBuffer)
@@ -687,13 +688,16 @@ class VideoStabilize:
                     borderValue=(0, 0, 0),
                 )
 
-                outputTensor = (
-                    torch.from_numpy(stabilized)
-                    .permute(2, 0, 1)
-                    .unsqueeze(0)
-                    .float()
-                    .div(255.0)
-                )
+                if self.writeHwcUint8:
+                    outputTensor = torch.from_numpy(np.ascontiguousarray(stabilized))
+                else:
+                    outputTensor = (
+                        torch.from_numpy(stabilized)
+                        .permute(2, 0, 1)
+                        .unsqueeze(0)
+                        .to(torch.float32)
+                    )
+                    outputTensor.mul_(1.0 / 255.0)
 
                 self.writeBuffer.write(outputTensor)
                 frameCount += 1

--- a/tests/test_ffmpeg_writer.py
+++ b/tests/test_ffmpeg_writer.py
@@ -38,3 +38,21 @@ def testWriteBufferInitialNoneSentinelExitsCleanly(monkeypatch, tmp_path):
     wb.writeBuffer.put(None)
 
     wb()
+
+
+def testNeluxWriteBufferBenchmarkConsumesFramesWithoutEncoder(monkeypatch, tmp_path):
+    _installFakeTorch(monkeypatch)
+    monkeypatch.setitem(sys.modules, "nelux", types.SimpleNamespace())
+    ffmpegSettings = importlib.import_module("src.io.ffmpegSettings")
+
+    wb = ffmpegSettings.NeluxWriteBuffer(
+        output=str(tmp_path / "out.mp4"),
+        benchmark=True,
+    )
+    wb.writeBuffer.put(object())
+    wb.writeBuffer.put(None)
+
+    wb()
+
+    assert wb.writtenFrames == 1
+    assert wb.encoder is None

--- a/tests/test_object_detection_fastpaths.py
+++ b/tests/test_object_detection_fastpaths.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("cv2")
+pytest.importorskip("onnxruntime")
+
+from src.objectDetection.objectDetection import (
+    _rescaleBoxes,
+    _writeOutputFrame,
+    _writeRgbFrame,
+)
+
+
+class _Writer:
+    def __init__(self):
+        self.frame = None
+
+    def write(self, frame):
+        self.frame = frame
+
+
+class _BoxOwner:
+    inputWidth = 10
+    inputHeight = 20
+    imgWidth = 100
+    imgHeight = 200
+    _boxScale = None
+    _boxScaleShape = None
+
+
+def testWriteOutputFrameCanEmitHwcUint8ForNelux():
+    writer = _Writer()
+    bgr = np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8)
+
+    _writeOutputFrame(writer, bgr, writeHwcUint8=True)
+
+    assert writer.frame.shape == (1, 2, 3)
+    assert writer.frame.dtype == torch.uint8
+    assert writer.frame.is_contiguous()
+    assert writer.frame.tolist() == [[[3, 2, 1], [6, 5, 4]]]
+
+
+def testWriteRgbFrameCanBypassColorConversionForNoDetections():
+    writer = _Writer()
+    rgb = np.array([[[3, 2, 1], [6, 5, 4]]], dtype=np.uint8)
+
+    _writeRgbFrame(writer, rgb, writeHwcUint8=True)
+
+    assert writer.frame.shape == (1, 2, 3)
+    assert writer.frame.dtype == torch.uint8
+    assert writer.frame.tolist() == [[[3, 2, 1], [6, 5, 4]]]
+
+
+def testWriteRgbFrameCanOwnDecoderBackedFrames():
+    writer = _Writer()
+    rgb = np.array([[[3, 2, 1]]], dtype=np.uint8)
+
+    _writeRgbFrame(writer, rgb, writeHwcUint8=True, copyHwc=True)
+    rgb[:] = 0
+
+    assert writer.frame.tolist() == [[[3, 2, 1]]]
+
+
+def testWriteOutputFrameKeepsBchwFloatForFfmpegWriter():
+    writer = _Writer()
+    bgr = np.array([[[0, 127, 255]]], dtype=np.uint8)
+
+    _writeOutputFrame(writer, bgr, writeHwcUint8=False)
+
+    assert writer.frame.shape == (1, 3, 1, 1)
+    assert writer.frame.dtype == torch.float32
+    assert torch.allclose(
+        writer.frame.flatten(),
+        torch.tensor([1.0, 127.0 / 255.0, 0.0], dtype=torch.float32),
+    )
+
+
+def testRescaleBoxesUsesCachedScaleInPlace():
+    owner = _BoxOwner()
+    boxes = np.array([[1, 2, 3, 4]], dtype=np.float32)
+
+    scaled = _rescaleBoxes(owner, boxes)
+
+    assert scaled is boxes
+    np.testing.assert_allclose(scaled, [[10, 20, 30, 40]])
+    assert owner._boxScaleShape == (100, 200)

--- a/tests/test_object_detection_fastpaths.py
+++ b/tests/test_object_detection_fastpaths.py
@@ -1,6 +1,6 @@
-import numpy as np
 import pytest
 
+np = pytest.importorskip("numpy")
 torch = pytest.importorskip("torch")
 pytest.importorskip("cv2")
 pytest.importorskip("onnxruntime")


### PR DESCRIPTION
## Summary
- replace same-thread interpolation Queue handoff with a list-backed collector
- let RGB standalone paths route through createWriteBuffer so *_nelux encoders can use NeluxWriteBuffer
- add a direct HWC uint8 path for Nelux RGB frames and use it for object detection/stabilization fast paths
- reduce object-detection preprocessing/output overhead and cache TensorRT RIFE timestep updates

## Measurements
- interpolation collector microbench: Queue ~2.01 us vs collector ~0.153 us per cycle (~13x)
- object-detection input prep microbench: ~1.72 ms -> ~0.75 ms (~2.3x)
- no-detection Nelux output prep microbench with owned copy: ~6.70 ms -> ~0.26 ms (~26x)

## Validation
- .venv/bin/python -m ruff check main.py benchmarks/perf/hotloop_microbench.py src/interpolate/rife_tensorrt.py src/objectDetection/objectDetection.py src/motionBlur.py src/stabilize/stabilize.py src/io/ffmpegSettings.py tests/test_object_detection_fastpaths.py
- .venv/bin/python -m pytest tests -q (276 passed, 5 existing torch deprecation warnings)