### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ All available parameters for interacting with the CLI or directly with `main.py`
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=NevermindNilas/TheAnimeScripter&type=Date)](https://star-history.com/#NevermindNilas/TheAnimeScripter&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=NevermindNilas/TheAnimeScripter&type=Date)](https://star-history.dera.page/#NevermindNilas/TheAnimeScripter&Date)
 
 ## 👥 Code Contributors
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the stargazer data it relies on is no longer available through the GitHub API. This switches the chart and its link to star-history.dera.page, a drop-in alternative that uses a different data source requiring no API token, so the chart renders correctly again.